### PR TITLE
Add some dependencies to gemspec

### DIFF
--- a/serverspec.gemspec
+++ b/serverspec.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "net-ssh"
   spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "rspec"
   spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
I add 'rspec' and 'net-ssh' gems to serverspec's gemspec file.
These gems are required in the repository.
