### PR TITLE
modify check_listening_port to support Solaris

### DIFF
--- a/lib/serverspec/commands/solaris.rb
+++ b/lib/serverspec/commands/solaris.rb
@@ -10,7 +10,7 @@ module Serverspec
       end
 
       def check_listening port
-        "netstat -an -P tcp 2> /dev/null | grep LISTEN | grep '\.#{port} '"
+        "netstat -an 2> /dev/null | egrep 'LISTEN|Idle' | grep '\.#{port} '"
       end
 
       def check_running service


### PR DESCRIPTION
I've modified check_listening_port in lib/serverspec/commands/solaris.rb to support Solaris.
