### PR TITLE
Add get_stdout to SshHelper

### DIFF
--- a/lib/serverspec/helper.rb
+++ b/lib/serverspec/helper.rb
@@ -6,6 +6,11 @@ module Serverspec
       ssh_exec!("sudo #{cmd}")
     end
 
+    def get_stdout(cmd)
+      ret = ssh_exec(cmd)
+      ret[:stdout]
+    end
+
     private
     def ssh_exec!(command)
       stdout_data = ''

--- a/spec/ssh_helper_spec.rb
+++ b/spec/ssh_helper_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+include Serverspec::SshHelper
+
+describe 'get the command stdout' do
+  subject do
+    get_stdout('whoami')
+  end
+
+  before do
+    RSpec.configure do |c|
+      c.stdout = "root\r\n"
+    end
+  end
+
+  it { should eq "root\r\n" }
+  it { should match /root/ }
+end


### PR DESCRIPTION
I want test the execute command stdout.
So, I've added `get_stdout` method to `Serverspec::SshHelper`.

e.g.

``` ruby
it { get_stdout('some-command').should match /expected/ }
```
