### PR TITLE
Change ps command to show more data to match.

### DIFF
--- a/lib/serverspec/commands/base.rb
+++ b/lib/serverspec/commands/base.rb
@@ -36,7 +36,7 @@ module Serverspec
       end
 
       def check_process process
-        "ps -e | grep -qw #{process}"
+        "ps aux | grep -qw #{process}"
       end
 
       def check_file_contain file, expected_pattern


### PR DESCRIPTION
ps -e doesn't show enough data to match if the process name doesn't exactly match - this shows more data.

For example:

```
describe 'jetty' do
  it { should be_enabled }
  it { should be_running }
end
```

It shows as being enabled but it never shows as running because it's running under Java. This is the command for jetty:

```
/usr/bin/java -Dsolr.solr.home=/opt/solr -Djetty.port=8085 -Djetty.home=/opt/jetty -Djava.io.tmpdir=/tmp -jar /opt/jetty/start.jar --pre=etc/jetty-logging.xml --daemon
```

I'm not sure how cross platform this change is.
