### PR TITLE
Add condition to be_running matcher

### DIFF
--- a/lib/serverspec/matchers/be_running.rb
+++ b/lib/serverspec/matchers/be_running.rb
@@ -1,7 +1,7 @@
 RSpec::Matchers.define :be_running do
   match do |actual|
     ret = ssh_exec(commands.check_running(actual))
-    if ret[:exit_code] == 1
+    if ret[:exit_code] == 1 || ret[:stdout] =~ /stopped/
       ret = ssh_exec(commands.check_process(actual))
     end
     ret[:exit_code] == 0

--- a/spec/support/shared_matcher_examples.rb
+++ b/spec/support/shared_matcher_examples.rb
@@ -32,6 +32,19 @@ shared_examples_for 'support be_running matcher' do |valid_service|
     describe 'this-is-invalid-daemon' do
       it { should_not be_running }
     end
+
+  end
+
+  describe 'be_process' do
+    describe valid_service do
+      before :all do
+        RSpec.configure do |c|
+          c.stdout = "#{valid_service} is stopped\r\n"
+        end
+      end
+
+      it { should be_running }
+    end
   end
 end
 


### PR DESCRIPTION
I'm using another daemon management tool for running the httpd. Like supervisor or daemontools.

So, I've added condition to the `be_running` matcher.
If service command returns 'httpd is stopped' check the httpd process by 'check_process' method.
