### PR TITLE
Add chain from() and to() to contain mathcer

### DIFF
--- a/lib/serverspec/commands/base.rb
+++ b/lib/serverspec/commands/base.rb
@@ -43,6 +43,13 @@ module Serverspec
         "grep -q '#{expected_pattern}' #{file}"
       end
 
+      def check_file_contain_within file, expected_pattern, from=nil, to=nil
+        from ||= '1'
+        to ||= '$'
+        checker = check_file_contain("-", expected_pattern)
+        "sed -n '#{from},#{to}p' #{file} | #{checker}"
+      end
+
       def check_mode file, mode
         "stat -c %a #{file} | grep #{mode}"
       end

--- a/lib/serverspec/matchers/contain.rb
+++ b/lib/serverspec/matchers/contain.rb
@@ -1,6 +1,17 @@
 RSpec::Matchers.define :contain do |expected|
   match do |actual|
-    ret = ssh_exec(commands.check_file_contain(actual, expected))
+    if (@from || @to).nil?
+      cmd = commands.check_file_contain(actual, expected)
+    else
+      cmd = commands.check_file_contain_within(actual, expected, @from, @to)
+    end
+    ret = ssh_exec(cmd)
     ret[:exit_code] == 0
+  end
+  chain :from do |from|
+    @from = Regexp.new(from).inspect
+  end
+  chain :to do |to|
+    @to = Regexp.new(to).inspect
   end
 end

--- a/spec/debian/commands_spec.rb
+++ b/spec/debian/commands_spec.rb
@@ -42,6 +42,22 @@ describe commands.check_file_contain('/etc/passwd', 'root') do
   it { should eq "grep -q 'root' /etc/passwd" }
 end
 
+describe commands.check_file_contain_within('Gemfile', 'rspec') do
+  it { should eq "sed -n '1,$p' Gemfile | grep -q 'rspec' -" }
+end
+
+describe commands.check_file_contain_within('Gemfile', 'rspec', '/^group :test do/') do
+  it { should eq "sed -n '/^group :test do/,$p' Gemfile | grep -q 'rspec' -" }
+end
+
+describe commands.check_file_contain_within('Gemfile', 'rspec', nil, '/^end/') do
+  it { should eq "sed -n '1,/^end/p' Gemfile | grep -q 'rspec' -" }
+end
+
+describe commands.check_file_contain_within('Gemfile', 'rspec', '/^group :test do/', '/^end/') do
+  it { should eq "sed -n '/^group :test do/,/^end/p' Gemfile | grep -q 'rspec' -" }
+end
+
 describe commands.check_mode('/etc/sudoers', 440) do
   it { should eq 'stat -c %a /etc/sudoers | grep 440' }
 end

--- a/spec/debian/matchers_spec.rb
+++ b/spec/debian/matchers_spec.rb
@@ -7,6 +7,7 @@ describe 'Serverspec matchers of Debian family', :os => :debian do
   it_behaves_like 'support be_listening matcher', 22
   it_behaves_like 'support be_file matcher', '/etc/ssh/sshd_config'
   it_behaves_like 'support contain matcher', '/etc/ssh/sshd_config', 'See the sshd_config(5) manpage'
+  it_behaves_like 'support contain.from.to matcher', 'Gemfile', 'rspec', /^group :test do/, /^end/
   it_behaves_like 'support be_user matcher', 'root'
   it_behaves_like 'support be_group matcher', 'wheel'
 

--- a/spec/gentoo/commands_spec.rb
+++ b/spec/gentoo/commands_spec.rb
@@ -42,6 +42,22 @@ describe commands.check_file_contain('/etc/passwd', 'root') do
   it { should eq "grep -q 'root' /etc/passwd" }
 end
 
+describe commands.check_file_contain_within('Gemfile', 'rspec') do
+  it { should eq "sed -n '1,$p' Gemfile | grep -q 'rspec' -" }
+end
+
+describe commands.check_file_contain_within('Gemfile', 'rspec', '/^group :test do/') do
+  it { should eq "sed -n '/^group :test do/,$p' Gemfile | grep -q 'rspec' -" }
+end
+
+describe commands.check_file_contain_within('Gemfile', 'rspec', nil, '/^end/') do
+  it { should eq "sed -n '1,/^end/p' Gemfile | grep -q 'rspec' -" }
+end
+
+describe commands.check_file_contain_within('Gemfile', 'rspec', '/^group :test do/', '/^end/') do
+  it { should eq "sed -n '/^group :test do/,/^end/p' Gemfile | grep -q 'rspec' -" }
+end
+
 describe commands.check_mode('/etc/sudoers', 440) do
   it { should eq 'stat -c %a /etc/sudoers | grep 440' }
 end

--- a/spec/gentoo/matchers_spec.rb
+++ b/spec/gentoo/matchers_spec.rb
@@ -8,6 +8,7 @@ describe 'Serverspec matchers of Gentoo family', :os => :gentoo do
   it_behaves_like 'support be_file matcher', '/etc/ssh/sshd_config'
   it_behaves_like 'support be_directory matcher', '/etc/ssh'
   it_behaves_like 'support contain matcher', '/etc/ssh/sshd_config', 'This is the sshd server system-wide configuration file'
+  it_behaves_like 'support contain.from.to matcher', 'Gemfile', 'rspec', /^group :test do/, /^end/
   it_behaves_like 'support be_user matcher', 'root'
   it_behaves_like 'support be_group matcher', 'wheel'
 

--- a/spec/redhat/commands_spec.rb
+++ b/spec/redhat/commands_spec.rb
@@ -42,6 +42,22 @@ describe commands.check_file_contain('/etc/passwd', 'root') do
   it { should eq "grep -q 'root' /etc/passwd" }
 end
 
+describe commands.check_file_contain_within('Gemfile', 'rspec') do
+  it { should eq "sed -n '1,$p' Gemfile | grep -q 'rspec' -" }
+end
+
+describe commands.check_file_contain_within('Gemfile', 'rspec', '/^group :test do/') do
+  it { should eq "sed -n '/^group :test do/,$p' Gemfile | grep -q 'rspec' -" }
+end
+
+describe commands.check_file_contain_within('Gemfile', 'rspec', nil, '/^end/') do
+  it { should eq "sed -n '1,/^end/p' Gemfile | grep -q 'rspec' -" }
+end
+
+describe commands.check_file_contain_within('Gemfile', 'rspec', '/^group :test do/', '/^end/') do
+  it { should eq "sed -n '/^group :test do/,/^end/p' Gemfile | grep -q 'rspec' -" }
+end
+
 describe commands.check_mode('/etc/sudoers', 440) do
   it { should eq 'stat -c %a /etc/sudoers | grep 440' }
 end

--- a/spec/redhat/matchers_spec.rb
+++ b/spec/redhat/matchers_spec.rb
@@ -8,6 +8,7 @@ describe 'Serverspec matchers of Red Hat family', :os => :redhat do
   it_behaves_like 'support be_file matcher', '/etc/ssh/sshd_config'
   it_behaves_like 'support be_directory matcher', '/etc/ssh'
   it_behaves_like 'support contain matcher', '/etc/ssh/sshd_config', 'This is the sshd server system-wide configuration file'
+  it_behaves_like 'support contain.from.to matcher', 'Gemfile', 'rspec', /^group :test do/, /^end/
   it_behaves_like 'support be_user matcher', 'root'
   it_behaves_like 'support be_group matcher', 'wheel'
 

--- a/spec/solaris/commads_spec.rb
+++ b/spec/solaris/commads_spec.rb
@@ -42,6 +42,22 @@ describe commands.check_file_contain('/etc/passwd', 'root') do
   it { should eq "grep -q 'root' /etc/passwd" }
 end
 
+describe commands.check_file_contain_within('Gemfile', 'rspec') do
+  it { should eq "sed -n '1,$p' Gemfile | grep -q 'rspec' -" }
+end
+
+describe commands.check_file_contain_within('Gemfile', 'rspec', '/^group :test do/') do
+  it { should eq "sed -n '/^group :test do/,$p' Gemfile | grep -q 'rspec' -" }
+end
+
+describe commands.check_file_contain_within('Gemfile', 'rspec', nil, '/^end/') do
+  it { should eq "sed -n '1,/^end/p' Gemfile | grep -q 'rspec' -" }
+end
+
+describe commands.check_file_contain_within('Gemfile', 'rspec', '/^group :test do/', '/^end/') do
+  it { should eq "sed -n '/^group :test do/,/^end/p' Gemfile | grep -q 'rspec' -" }
+end
+
 describe commands.check_mode('/etc/sudoers', 440) do
   it { should eq 'stat -c %a /etc/sudoers | grep 440' }
 end

--- a/spec/solaris/matchers_spec.rb
+++ b/spec/solaris/matchers_spec.rb
@@ -8,6 +8,7 @@ describe 'Serverspec matchers of Solaris family', :os => :solaris do
   it_behaves_like 'support be_file matcher', '/etc/ssh/sshd_config'
   it_behaves_like 'support be_directory matcher', '/etc/ssh'
   it_behaves_like 'support contain matcher', '/etc/ssh/sshd_config', 'Configuration file for sshd(1m) (see also sshd_config(4))'
+  it_behaves_like 'support contain.from.to matcher', 'Gemfile', 'rspec', /^group :test do/, /^end/
   it_behaves_like 'support be_user matcher', 'root'
   it_behaves_like 'support be_group matcher', 'root'
 

--- a/spec/support/shared_matcher_examples.rb
+++ b/spec/support/shared_matcher_examples.rb
@@ -92,6 +92,18 @@ shared_examples_for 'support contain matcher' do |valid_file, pattern|
   end
 end
 
+shared_examples_for 'support contain.from.to matcher' do |valid_file, pattern, from, to|
+  describe 'contain' do
+    describe valid_file do
+      it { should contain(pattern).from(from).to(to) }
+    end
+
+    describe '/etc/ssh/sshd_config' do
+      it { should_not contain('This is invalid text!!').from(from).to(to) }
+    end
+  end
+end
+
 shared_examples_for 'support be_user matcher' do |valid_user|
   describe 'be_user' do
     describe valid_user do


### PR DESCRIPTION
Support checking `contain()` matcher within the range specified in the file

e.g.

``` sh
$ cat Gemfile 

group :test do
  gem 'rspec'
end

group :doc do
  gem 'rdoc'
end
```

``` ruby
describe 'Gemfile' do
  it { should be_file }

  # check contain this file
  it { should contain 'rspec' }
  it { should contain 'rdoc' }

  # check contain ahead of 'group :test do ; end'
  it { should_not contain('rspec').to(/^group :test do/) }
  it { should_not contain('rdoc').to(/^group :test do/) }

  # check contain behind 'group :test do ; end'
  it { should contain('rspec').from(/^group :test do/) }
  it { should contain('rdoc').from(/^group :test do/) }

  # check contain within 'group :test do ; end'
  it { should contain('rspec').from(/^group :test do/).to(/^end/) }
  it { should_not contain('rdoc').from(/^group :test do/).to(/^end/) }

  # check contain within 'group :doc do ; end'
  it { should_not contain('rspec').from(/^group :doc do/).to(/^end/) }
  it { should contain('rdoc').from(/^group :doc do/).to(/^end/) }
end
```
