### PR TITLE
This fix hides the grep process from the first grep - which now notifies you if your process is not running.

### DIFF
--- a/lib/serverspec/commands/base.rb
+++ b/lib/serverspec/commands/base.rb
@@ -36,7 +36,7 @@ module Serverspec
       end
 
       def check_process process
-        "ps aux | grep -qw #{process}"
+        "ps aux | grep -w #{process} | grep -qv grep"
       end
 
       def check_file_contain file, expected_pattern

--- a/lib/serverspec/version.rb
+++ b/lib/serverspec/version.rb
@@ -1,3 +1,3 @@
 module Serverspec
-  VERSION = "0.1.5"
+  VERSION = "0.1.6"
 end


### PR DESCRIPTION
I'm not sure how cross platform it is - but it appears to work on Ubuntu linux.

There's a few other options to do this - lots of info here:

http://serverfault.com/questions/367921/how-to-prevent-ps-reporting-its-own-process

This was the simplest and works properly in my test case.
