### PR TITLE
Fix installed_by_gem edge effect

### DIFF
--- a/lib/serverspec/commands/base.rb
+++ b/lib/serverspec/commands/base.rb
@@ -72,7 +72,7 @@ module Serverspec
       end
 
       def check_installed_by_gem name
-        "gem list --local | grep #{name}"
+        "gem list --local | grep '^#{name} '"
       end
 
       def check_belonging_group user, group

--- a/spec/debian/commands_spec.rb
+++ b/spec/debian/commands_spec.rb
@@ -79,7 +79,7 @@ describe commands.check_link('/etc/system-release', '/etc/redhat-release') do
 end
 
 describe commands.check_installed_by_gem('jekyll') do
-  it { should eq 'gem list --local | grep jekyll' }
+  it { should eq 'gem list --local | grep \'^jekyll \'' }
 end
 
 describe commands.check_belonging_group('root', 'wheel') do

--- a/spec/gentoo/commands_spec.rb
+++ b/spec/gentoo/commands_spec.rb
@@ -79,7 +79,7 @@ describe commands.check_link('/etc/system-release', '/etc/redhat-release') do
 end
 
 describe commands.check_installed_by_gem('jekyll') do
-  it { should eq 'gem list --local | grep jekyll' }
+  it { should eq 'gem list --local | grep \'^jekyll \'' }
 end
 
 describe commands.check_belonging_group('root', 'wheel') do

--- a/spec/redhat/commands_spec.rb
+++ b/spec/redhat/commands_spec.rb
@@ -79,7 +79,7 @@ describe commands.check_link('/etc/system-release', '/etc/redhat-release') do
 end
 
 describe commands.check_installed_by_gem('jekyll') do
-  it { should eq 'gem list --local | grep jekyll' }
+  it { should eq 'gem list --local | grep \'^jekyll \'' }
 end
 
 describe commands.check_belonging_group('root', 'wheel') do

--- a/spec/solaris/commads_spec.rb
+++ b/spec/solaris/commads_spec.rb
@@ -79,7 +79,7 @@ describe commands.check_link('/etc/system-release', '/etc/redhat-release') do
 end
 
 describe commands.check_installed_by_gem('jekyll') do
-  it { should eq 'gem list --local | grep jekyll' }
+  it { should eq 'gem list --local | grep \'^jekyll \'' }
 end
 
 describe commands.check_belonging_group('root', 'wheel') do


### PR DESCRIPTION
Otherwise it says `ssh` is installed when `net-ssh` is installed.
