### PR TITLE
Support multiple properties with be_zfs matcher and fix edge case

### DIFF
--- a/lib/serverspec/commands/solaris.rb
+++ b/lib/serverspec/commands/solaris.rb
@@ -28,7 +28,7 @@ module Serverspec
         else
           commands = []
           property.sort.each do |key, value|
-            commands << "/sbin/zfs get -H #{key} #{zfs} | grep ' #{value} '"
+            commands << "/sbin/zfs list -H -o #{key} #{zfs} | grep ^#{value}$"
           end
           commands.join(' && ')
         end

--- a/spec/solaris/commads_spec.rb
+++ b/spec/solaris/commads_spec.rb
@@ -91,11 +91,11 @@ describe commands.check_zfs('rpool') do
 end
 
 describe commands.check_zfs('rpool', { 'mountpoint' => '/rpool' }) do
-  it { should eq "/sbin/zfs get -H mountpoint rpool | grep ' /rpool '" }
+  it { should eq "/sbin/zfs list -H -o mountpoint rpool | grep ^/rpool$" }
 end
 
 describe commands.check_zfs('rpool', { 'mountpoint' => '/rpool' }) do
-  it { should eq "/sbin/zfs get -H mountpoint rpool | grep ' /rpool '" }
+  it { should eq "/sbin/zfs list -H -o mountpoint rpool | grep ^/rpool$" }
 end
 
 check_zfs_with_multiple_properties = commands.check_zfs('rpool', {
@@ -104,5 +104,5 @@ check_zfs_with_multiple_properties = commands.check_zfs('rpool', {
 })
 
 describe check_zfs_with_multiple_properties do
-  it { should eq "/sbin/zfs get -H compression rpool | grep ' off ' && /sbin/zfs get -H mountpoint rpool | grep ' /rpool '" }
+  it { should eq "/sbin/zfs list -H -o compression rpool | grep ^off$ && /sbin/zfs list -H -o mountpoint rpool | grep ^/rpool$" }
 end


### PR DESCRIPTION
I've fixed the edge case mentioned in #40 .

And also I've added a feature that be_zfs.with takes multple properties like this.

``` ruby
it do
  should be_zfs.with(
    'mountpoint'  => '/rpool',
    'compression' => 'off'
  )
end
```

@ftnk , I appreciate if you check them.
