### PR TITLE
Fix stat commands for exact match

### DIFF
--- a/lib/serverspec/commands/base.rb
+++ b/lib/serverspec/commands/base.rb
@@ -51,15 +51,15 @@ module Serverspec
       end
 
       def check_mode file, mode
-        "stat -c %a #{file} | grep #{mode}"
+        "stat -c %a #{file} | grep '^#{mode}$'"
       end
 
       def check_owner file, owner
-        "stat -c %U #{file} | grep #{owner}"
+        "stat -c %U #{file} | grep '^#{owner}$'"
       end
 
       def check_grouped file, group
-        "stat -c %G #{file} | grep #{group}"
+        "stat -c %G #{file} | grep '^#{group}$'"
       end
 
       def check_cron_entry user, entry

--- a/spec/debian/commands_spec.rb
+++ b/spec/debian/commands_spec.rb
@@ -59,15 +59,15 @@ describe commands.check_file_contain_within('Gemfile', 'rspec', '/^group :test d
 end
 
 describe commands.check_mode('/etc/sudoers', 440) do
-  it { should eq 'stat -c %a /etc/sudoers | grep 440' }
+  it { should eq 'stat -c %a /etc/sudoers | grep \'^440$\'' }
 end
 
 describe commands.check_owner('/etc/passwd', 'root') do
-  it { should eq 'stat -c %U /etc/passwd | grep root' }
+  it { should eq 'stat -c %U /etc/passwd | grep \'^root$\'' }
 end
 
 describe commands.check_grouped('/etc/passwd', 'wheel') do
-  it { should eq 'stat -c %G /etc/passwd | grep wheel' }
+  it { should eq 'stat -c %G /etc/passwd | grep \'^wheel$\'' }
 end
 
 describe commands.check_cron_entry('root', '* * * * * /usr/local/bin/batch.sh') do

--- a/spec/gentoo/commands_spec.rb
+++ b/spec/gentoo/commands_spec.rb
@@ -59,15 +59,15 @@ describe commands.check_file_contain_within('Gemfile', 'rspec', '/^group :test d
 end
 
 describe commands.check_mode('/etc/sudoers', 440) do
-  it { should eq 'stat -c %a /etc/sudoers | grep 440' }
+  it { should eq 'stat -c %a /etc/sudoers | grep \'^440$\'' }
 end
 
 describe commands.check_owner('/etc/passwd', 'root') do
-  it { should eq 'stat -c %U /etc/passwd | grep root' }
+  it { should eq 'stat -c %U /etc/passwd | grep \'^root$\'' }
 end
 
 describe commands.check_grouped('/etc/passwd', 'wheel') do
-  it { should eq 'stat -c %G /etc/passwd | grep wheel' }
+  it { should eq 'stat -c %G /etc/passwd | grep \'^wheel$\'' }
 end
 
 describe commands.check_cron_entry('root', '* * * * * /usr/local/bin/batch.sh') do

--- a/spec/redhat/commands_spec.rb
+++ b/spec/redhat/commands_spec.rb
@@ -59,15 +59,15 @@ describe commands.check_file_contain_within('Gemfile', 'rspec', '/^group :test d
 end
 
 describe commands.check_mode('/etc/sudoers', 440) do
-  it { should eq 'stat -c %a /etc/sudoers | grep 440' }
+  it { should eq 'stat -c %a /etc/sudoers | grep \'^440$\'' }
 end
 
 describe commands.check_owner('/etc/passwd', 'root') do
-  it { should eq 'stat -c %U /etc/passwd | grep root' }
+  it { should eq 'stat -c %U /etc/passwd | grep \'^root$\'' }
 end
 
 describe commands.check_grouped('/etc/passwd', 'wheel') do
-  it { should eq 'stat -c %G /etc/passwd | grep wheel' }
+  it { should eq 'stat -c %G /etc/passwd | grep \'^wheel$\'' }
 end
 
 describe commands.check_cron_entry('root', '* * * * * /usr/local/bin/batch.sh') do

--- a/spec/solaris/commads_spec.rb
+++ b/spec/solaris/commads_spec.rb
@@ -59,15 +59,15 @@ describe commands.check_file_contain_within('Gemfile', 'rspec', '/^group :test d
 end
 
 describe commands.check_mode('/etc/sudoers', 440) do
-  it { should eq 'stat -c %a /etc/sudoers | grep 440' }
+  it { should eq 'stat -c %a /etc/sudoers | grep \'^440$\'' }
 end
 
 describe commands.check_owner('/etc/passwd', 'root') do
-  it { should eq 'stat -c %U /etc/passwd | grep root' }
+  it { should eq 'stat -c %U /etc/passwd | grep \'^root$\'' }
 end
 
 describe commands.check_grouped('/etc/passwd', 'wheel') do
-  it { should eq 'stat -c %G /etc/passwd | grep wheel' }
+  it { should eq 'stat -c %G /etc/passwd | grep \'^wheel$\'' }
 end
 
 describe commands.check_cron_entry('root', '* * * * * /usr/local/bin/batch.sh') do


### PR DESCRIPTION
Otherwise, `/etc/passwd` might belong to `roo`.
