### PR TITLE
Add dependency rspec to gemspec

### DIFF
--- a/serverspec.gemspec
+++ b/serverspec.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "net-ssh"
+  spec.add_dependency "rspec"
   spec.add_development_dependency "bundler", "~> 1.3"
-  spec.add_development_dependency "rspec"
   spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
Change the type of dependency
serverspec の rspec についての dependency を変更しました。
これで、serverspec のインストール後に rspec のインストールを迫られることはありません :ramen: 
