### PR TITLE
Send example to backend

### DIFF
--- a/lib/serverspec/backend/exec.rb
+++ b/lib/serverspec/backend/exec.rb
@@ -22,31 +22,31 @@ module Serverspec
         ret[:exit_code] == 0
       end
 
-      def check_directory(directory)
+      def check_directory(example, directory)
         check_zero(:check_directory, directory)
       end
 
-      def check_enabled(service)
+      def check_enabled(example, service)
         check_zero(:check_enabled, service)
       end
 
-      def check_file(file)
+      def check_file(example, file)
         check_zero(:check_file, file)
       end
 
-      def check_group(group)
+      def check_group(example, group)
         check_zero(:check_group, group)
       end
 
-      def check_grouped(file, group)
+      def check_grouped(example, file, group)
         check_zero(:check_grouped, file, group)
       end
 
-      def check_installed(package)
+      def check_installed(example, package)
         check_zero(:check_installed, package)
       end
 
-      def check_installed_by_gem(package, version)
+      def check_installed_by_gem(example, package, version)
         ret = do_check(commands.check_installed_by_gem(package))
         res = ret[:exit_code] == 0
         if res && version
@@ -55,23 +55,23 @@ module Serverspec
         res
       end
 
-      def check_link(link, target)
+      def check_link(example, link, target)
         check_zero(:check_link, link, target)
       end
 
-      def check_listening(port)
+      def check_listening(example, port)
         check_zero(:check_listening, port)
       end
 
-      def check_mode(file, mode)
+      def check_mode(example, file, mode)
         check_zero(:check_mode, file, mode)
       end
 
-      def check_owner(file, owner)
+      def check_owner(example, file, owner)
         check_zero(:check_owner, file, owner)
       end
 
-      def check_running(process)
+      def check_running(example, process)
         ret = do_check(commands.check_running(process))
         if ret[:exit_code] == 1 || ret[:stdout] =~ /stopped/
           ret = do_check(commands.check_process(process))
@@ -79,32 +79,32 @@ module Serverspec
         ret[:exit_code] == 0
       end
 
-      def check_running_under_supervisor(process)
+      def check_running_under_supervisor(example, process)
         ret = do_check(commands.check_running_under_supervisor(process))
         ret[:exit_code] == 0 && ret[:stdout] =~ /RUNNING/
       end
 
-      def check_user(user)
+      def check_user(example, user)
         check_zero(:check_user, user)
       end
 
-      def check_belonging_group(user, group)
+      def check_belonging_group(example, user, group)
         check_zero(:check_belonging_group, user, group)
       end
 
-      def check_cron_entry(user, entry)
+      def check_cron_entry(example, user, entry)
         check_zero(:check_cron_entry, user, entry)
       end
 
-      def check_iptables_rule(rule, table, chain)
+      def check_iptables_rule(example, rule, table, chain)
         check_zero(:check_iptables_rule, rule, table, chain)
       end
 
-      def check_zfs(zfs, property)
+      def check_zfs(example, zfs, property)
         check_zero(:check_zfs, zfs, property)
       end
 
-      def check_readable(file, by_whom)
+      def check_readable(example, file, by_whom)
         mode = sprintf('%04s',do_check(commands.get_mode(file))[:stdout].strip)
         mode_octal = mode[0].to_i * 512 + mode[1].to_i * 64 + mode[2].to_i * 8 + mode[3].to_i * 1
         if by_whom.nil?
@@ -118,7 +118,7 @@ module Serverspec
         end
       end
 
-      def check_writable(file, by_whom)
+      def check_writable(example, file, by_whom)
         mode = sprintf('%04s',do_check(commands.get_mode(file))[:stdout].strip)
         mode_octal = mode[0].to_i * 512 + mode[1].to_i * 64 + mode[2].to_i * 8 + mode[3].to_i * 1
         if by_whom.nil?
@@ -132,7 +132,7 @@ module Serverspec
         end
       end
 
-      def check_executable(file, by_whom)
+      def check_executable(example, file, by_whom)
         mode = sprintf('%04s',do_check(commands.get_mode(file))[:stdout].strip)
         mode_octal = mode[0].to_i * 512 + mode[1].to_i * 64 + mode[2].to_i * 8 + mode[3].to_i * 1
         if by_whom.nil?

--- a/lib/serverspec/backend/puppet.rb
+++ b/lib/serverspec/backend/puppet.rb
@@ -9,22 +9,22 @@ module Serverspec
   module Backend
     class Puppet < Exec # Use Exec methods as fallbacks
 
-      def check_directory(directory)
+      def check_directory(example, directory)
         d = ::Puppet::Type::File.new(:name => directory, :ensure => 'directory')
         d.insync?(d.retrieve)
       end
 
-      def check_enabled(service)
+      def check_enabled(example, service)
         s = ::Puppet::Type::Service.new(:name => service, :enable => 'true')
         s.insync?(s.retrieve)
       end
 
-      def check_file(file)
+      def check_file(example, file)
         f = ::Puppet::Type::File.new(:name => file, :ensure => 'file')
         f.insync?(f.retrieve)
       end
 
-      def check_group(group)
+      def check_group(example, group)
         g = ::Puppet::Type::Group.new(:name => group)
         g_real = g.retrieve
         if g.provider.exists?
@@ -34,12 +34,12 @@ module Serverspec
         end
       end
 
-      def check_grouped(file, group)
+      def check_grouped(example, file, group)
         f = ::Puppet::Type::File.new(:name => file, :group => group)
         f.insync?(f.retrieve)
       end
 
-      def check_installed(package)
+      def check_installed(example, package)
         p = ::Puppet::Type::Package.new(:name => package)
         p_real = p.retrieve
         if p.exists?
@@ -49,7 +49,7 @@ module Serverspec
         end
       end
 
-      def check_installed_by_gem(package, version)
+      def check_installed_by_gem(example, package, version)
         p = ::Puppet::Type::Package.new(:name => package, :provider => 'gem',
                                         :ensure => version || 'present')
         p_real = p.retrieve
@@ -60,29 +60,29 @@ module Serverspec
         end
       end
 
-      def check_link(link, target)
+      def check_link(example, link, target)
         f = ::Puppet::Type::File.new(:name => link, :ensure => 'link', :target => target)
         f.insync?(f.retrieve)
       end
 
       # check_listening: inherited
 
-      def check_mode(file, mode)
+      def check_mode(example, file, mode)
         f = ::Puppet::Type::File.new(:name => file, :mode => mode)
         f.insync?(f.retrieve)
       end
 
-      def check_owner(file, owner)
+      def check_owner(example, file, owner)
         f = ::Puppet::Type::File.new(:name => file, :owner => owner)
         f.insync?(f.retrieve)
       end
 
-      def check_running(process)
+      def check_running(example, process)
         s = ::Puppet::Type::Service.new(:name => process, :ensure => 'running')
         s.insync?(s.retrieve)
       end
 
-      def check_user(user)
+      def check_user(example, user)
         u = ::Puppet::Type::User.new(:name => user)
         u_real = u.retrieve
         if u.provider.exists?

--- a/lib/serverspec/matchers/be_directory.rb
+++ b/lib/serverspec/matchers/be_directory.rb
@@ -1,5 +1,5 @@
 RSpec::Matchers.define :be_directory do
   match do |actual|
-    backend.check_directory(actual)
+    backend.check_directory(example, actual)
   end
 end

--- a/lib/serverspec/matchers/be_enabled.rb
+++ b/lib/serverspec/matchers/be_enabled.rb
@@ -1,5 +1,5 @@
 RSpec::Matchers.define :be_enabled do
   match do |actual|
-    backend.check_enabled(actual)
+    backend.check_enabled(example, actual)
   end
 end

--- a/lib/serverspec/matchers/be_executable.rb
+++ b/lib/serverspec/matchers/be_executable.rb
@@ -1,6 +1,6 @@
 RSpec::Matchers.define :be_executable do
   match do |file|
-    backend.check_executable(file, @by_whom)
+    backend.check_executable(example, file, @by_whom)
   end
   chain :by do |by_whom|
     @by_whom = by_whom

--- a/lib/serverspec/matchers/be_file.rb
+++ b/lib/serverspec/matchers/be_file.rb
@@ -1,5 +1,5 @@
 RSpec::Matchers.define :be_file do
   match do |actual|
-    backend.check_file(actual)
+    backend.check_file(example, actual)
   end
 end

--- a/lib/serverspec/matchers/be_group.rb
+++ b/lib/serverspec/matchers/be_group.rb
@@ -1,5 +1,5 @@
 RSpec::Matchers.define :be_group do
   match do |actual|
-    backend.check_group(actual)
+    backend.check_group(example, actual)
   end
 end

--- a/lib/serverspec/matchers/be_grouped_into.rb
+++ b/lib/serverspec/matchers/be_grouped_into.rb
@@ -1,5 +1,5 @@
 RSpec::Matchers.define :be_grouped_into do |group|
   match do |file|
-    backend.check_grouped(file, group)
+    backend.check_grouped(example, file, group)
   end
 end

--- a/lib/serverspec/matchers/be_installed.rb
+++ b/lib/serverspec/matchers/be_installed.rb
@@ -1,7 +1,7 @@
 RSpec::Matchers.define :be_installed do
   match do |name|
     if @provider.nil?
-      backend.check_installed(name)
+      backend.check_installed(example, name)
     else
       check_method = "check_installed_by_#{@provider}".to_sym
 
@@ -9,7 +9,7 @@ RSpec::Matchers.define :be_installed do
         raise ArgumentError.new("`be_installed` matcher doesn't support #{@under}")
       end
 
-      backend.send(check_method, name, @version)
+      backend.send(check_method, example, name, @version)
     end
   end
 

--- a/lib/serverspec/matchers/be_installed_by_gem.rb
+++ b/lib/serverspec/matchers/be_installed_by_gem.rb
@@ -8,7 +8,7 @@ Please use be_installed.by('gem') instead.
 ***************************************************
 
 EOF
-    backend.check_installed_by_gem(name, @version)
+    backend.check_installed_by_gem(example, name, @version)
   end
   chain :with_version do |version|
     @version = version

--- a/lib/serverspec/matchers/be_linked_to.rb
+++ b/lib/serverspec/matchers/be_linked_to.rb
@@ -1,5 +1,5 @@
 RSpec::Matchers.define :be_linked_to do |target|
   match do |link|
-    backend.check_link(link, target)
+    backend.check_link(example, link, target)
   end
 end

--- a/lib/serverspec/matchers/be_listening.rb
+++ b/lib/serverspec/matchers/be_listening.rb
@@ -1,6 +1,6 @@
 RSpec::Matchers.define :be_listening do
   match do |actual|
     port = actual.gsub(/port\s+/, '')
-    backend.check_listening(port)
+    backend.check_listening(example, port)
   end
 end

--- a/lib/serverspec/matchers/be_mode.rb
+++ b/lib/serverspec/matchers/be_mode.rb
@@ -1,5 +1,5 @@
 RSpec::Matchers.define :be_mode do |mode|
   match do |file|
-    backend.check_mode(file, mode)
+    backend.check_mode(example, file, mode)
   end
 end

--- a/lib/serverspec/matchers/be_owned_by.rb
+++ b/lib/serverspec/matchers/be_owned_by.rb
@@ -1,5 +1,5 @@
 RSpec::Matchers.define :be_owned_by do |owner|
   match do |file|
-    backend.check_owner(file, owner)
+    backend.check_owner(example, file, owner)
   end
 end

--- a/lib/serverspec/matchers/be_readable.rb
+++ b/lib/serverspec/matchers/be_readable.rb
@@ -1,6 +1,6 @@
 RSpec::Matchers.define :be_readable do
   match do |file|
-    backend.check_readable(file, @by_whom)
+    backend.check_readable(example, file, @by_whom)
   end
   chain :by do |by_whom|
     @by_whom = by_whom

--- a/lib/serverspec/matchers/be_running.rb
+++ b/lib/serverspec/matchers/be_running.rb
@@ -7,9 +7,9 @@ RSpec::Matchers.define :be_running do
         raise ArgumentError.new("`be_running` matcher doesn't support #{@under}")
       end
 
-      backend.send(check_method, process)
+      backend.send(check_method, example, process)
     else
-      backend.check_running(process)
+      backend.check_running(example, process)
     end
 
   end

--- a/lib/serverspec/matchers/be_user.rb
+++ b/lib/serverspec/matchers/be_user.rb
@@ -1,5 +1,5 @@
 RSpec::Matchers.define :be_user do
   match do |actual|
-    backend.check_user(actual)
+    backend.check_user(example, actual)
   end
 end

--- a/lib/serverspec/matchers/be_writable.rb
+++ b/lib/serverspec/matchers/be_writable.rb
@@ -1,6 +1,6 @@
 RSpec::Matchers.define :be_writable do
   match do |file|
-    backend.check_writable(file, @by_whom)
+    backend.check_writable(example, file, @by_whom)
   end
   chain :by do |by_whom|
     @by_whom = by_whom

--- a/lib/serverspec/matchers/be_zfs.rb
+++ b/lib/serverspec/matchers/be_zfs.rb
@@ -1,6 +1,6 @@
 RSpec::Matchers.define :be_zfs do
   match do |zfs|
-    backend.check_zfs(zfs, @property)
+    backend.check_zfs(example, zfs, @property)
   end
 
   chain :with do |property|

--- a/lib/serverspec/matchers/belong_to_group.rb
+++ b/lib/serverspec/matchers/belong_to_group.rb
@@ -1,5 +1,5 @@
 RSpec::Matchers.define :belong_to_group do |group|
   match do |user|
-    backend.check_belonging_group(user, group)
+    backend.check_belonging_group(example, user, group)
   end
 end

--- a/lib/serverspec/matchers/have_cron_entry.rb
+++ b/lib/serverspec/matchers/have_cron_entry.rb
@@ -1,7 +1,7 @@
 RSpec::Matchers.define :have_cron_entry do |entry|
   match do |actual|
     @user ||= 'root'
-    backend.check_cron_entry(@user, entry)
+    backend.check_cron_entry(example, @user, entry)
   end
   chain :with_user do |user|
     @user = user

--- a/lib/serverspec/matchers/have_iptables_rule.rb
+++ b/lib/serverspec/matchers/have_iptables_rule.rb
@@ -1,6 +1,6 @@
 RSpec::Matchers.define :have_iptables_rule do |rule|
   match do |iptables|
-    backend.check_iptables_rule(rule, @table, @chain)
+    backend.check_iptables_rule(example, rule, @table, @chain)
   end
   chain :with_table do |table|
     @table = table


### PR DESCRIPTION
This would allow to access `example` methods from the backends, such as `example.metadata` for filtering.
