### PR TITLE
Simplify Exec backend with a method_missing method

### DIFF
--- a/lib/serverspec/backend/exec.rb
+++ b/lib/serverspec/backend/exec.rb
@@ -22,28 +22,11 @@ module Serverspec
         ret[:exit_code] == 0
       end
 
-      def check_directory(example, directory)
-        check_zero(:check_directory, directory)
-      end
-
-      def check_enabled(example, service)
-        check_zero(:check_enabled, service)
-      end
-
-      def check_file(example, file)
-        check_zero(:check_file, file)
-      end
-
-      def check_group(example, group)
-        check_zero(:check_group, group)
-      end
-
-      def check_grouped(example, file, group)
-        check_zero(:check_grouped, file, group)
-      end
-
-      def check_installed(example, package)
-        check_zero(:check_installed, package)
+      # Default action is to call check_zero with args
+      def method_missing(meth, *args, &block)
+        # Remove example object from *args
+        args.shift
+        check_zero(meth, *args)
       end
 
       def check_installed_by_gem(example, package, version)
@@ -53,22 +36,6 @@ module Serverspec
           res = false if not ret[:stdout].match(/\(#{version}\)/)
         end
         res
-      end
-
-      def check_link(example, link, target)
-        check_zero(:check_link, link, target)
-      end
-
-      def check_listening(example, port)
-        check_zero(:check_listening, port)
-      end
-
-      def check_mode(example, file, mode)
-        check_zero(:check_mode, file, mode)
-      end
-
-      def check_owner(example, file, owner)
-        check_zero(:check_owner, file, owner)
       end
 
       def check_running(example, process)
@@ -82,26 +49,6 @@ module Serverspec
       def check_running_under_supervisor(example, process)
         ret = do_check(commands.check_running_under_supervisor(process))
         ret[:exit_code] == 0 && ret[:stdout] =~ /RUNNING/
-      end
-
-      def check_user(example, user)
-        check_zero(:check_user, user)
-      end
-
-      def check_belonging_group(example, user, group)
-        check_zero(:check_belonging_group, user, group)
-      end
-
-      def check_cron_entry(example, user, entry)
-        check_zero(:check_cron_entry, user, entry)
-      end
-
-      def check_iptables_rule(example, rule, table, chain)
-        check_zero(:check_iptables_rule, rule, table, chain)
-      end
-
-      def check_zfs(example, zfs, property)
-        check_zero(:check_zfs, zfs, property)
       end
 
       def check_readable(example, file, by_whom)


### PR DESCRIPTION
With this change, it gets easier to declare new matchers that only require a `check_zero` call on the Exec backend. Calling `check_zero` becomes the default action, and only actions that require another call need to be defined in the backend.
