### PR TITLE
Support handle sudo password

### DIFF
--- a/lib/serverspec.rb
+++ b/lib/serverspec.rb
@@ -17,6 +17,7 @@ RSpec.configure do |c|
   c.include(Serverspec::Helper::Debian,  :os => :debian)
   c.include(Serverspec::Helper::Gentoo,  :os => :gentoo)
   c.include(Serverspec::Helper::Solaris, :os => :solaris)
-  c.add_setting :host, :default => nil
-  c.add_setting :ssh,  :default => nil
+  c.add_setting :host,          :default => nil
+  c.add_setting :ssh,           :default => nil
+  c.add_setting :sudo_password, :default => nil
 end


### PR DESCRIPTION
I've implemented the issue #26

RSpec configuration example

``` ruby
# spec/spec_helper.rb
RSpec.configure do |c|
  c.before do
    # some configuration
    c.ssh   = Net::SSH.start(c.host, user, options)
    c.sudo_password = ENV['SUDO_PASSWORD']
  end
end
```

And run test.

``` sh
$ SUDO_PASSWORD=foobar rake spec
```
