### PR TITLE
fix belong_to_group to match groups(currently, matches only primary group)

### DIFF
--- a/lib/serverspec/commands/base.rb
+++ b/lib/serverspec/commands/base.rb
@@ -80,7 +80,7 @@ module Serverspec
       end
 
       def check_belonging_group user, group
-        "id #{user} | awk '{print $2}' | grep #{group}"
+        "id #{user} | awk '{print $3}' | grep #{group}"
       end
 
       def check_iptables_rule rule, table=nil, chain=nil

--- a/spec/debian/commands_spec.rb
+++ b/spec/debian/commands_spec.rb
@@ -87,7 +87,7 @@ describe commands.check_installed_by_gem('jekyll') do
 end
 
 describe commands.check_belonging_group('root', 'wheel') do
-  it { should eq "id root | awk '{print $2}' | grep wheel" }
+  it { should eq "id root | awk '{print $3}' | grep wheel" }
 end
 
 describe commands.check_iptables_rule('-P INPUT ACCEPT') do

--- a/spec/gentoo/commands_spec.rb
+++ b/spec/gentoo/commands_spec.rb
@@ -87,7 +87,7 @@ describe commands.check_installed_by_gem('jekyll') do
 end
 
 describe commands.check_belonging_group('root', 'wheel') do
-  it { should eq "id root | awk '{print $2}' | grep wheel" }
+  it { should eq "id root | awk '{print $3}' | grep wheel" }
 end
 
 describe commands.check_iptables_rule('-P INPUT ACCEPT') do

--- a/spec/redhat/commands_spec.rb
+++ b/spec/redhat/commands_spec.rb
@@ -87,7 +87,7 @@ describe commands.check_installed_by_gem('jekyll') do
 end
 
 describe commands.check_belonging_group('root', 'wheel') do
-  it { should eq "id root | awk '{print $2}' | grep wheel" }
+  it { should eq "id root | awk '{print $3}' | grep wheel" }
 end
 
 describe commands.check_iptables_rule('-P INPUT ACCEPT') do

--- a/spec/solaris/commands_spec.rb
+++ b/spec/solaris/commands_spec.rb
@@ -87,7 +87,7 @@ describe commands.check_installed_by_gem('jekyll') do
 end
 
 describe commands.check_belonging_group('root', 'wheel') do
-  it { should eq "id root | awk '{print $2}' | grep wheel" }
+  it { should eq "id root | awk '{print $3}' | grep wheel" }
 end
 
 describe commands.check_zfs('rpool') do


### PR DESCRIPTION
belong_to_group matcher can check primary group in my env.
(gid=xxx(name) was printed by awk in this command)

```
$ id #{user} | awk '{print $2}' | grep #{group}
```

I want to check all group belongs_to subject user.

please merge this request if you want too.
