### PR TITLE
Some fixes in spec_helper created by serverspec-init

### DIFF
--- a/lib/serverspec/setup.rb
+++ b/lib/serverspec/setup.rb
@@ -100,8 +100,9 @@ EOF
           case @backend_type
             when 'Ssh'
               content.gsub!(/### include requirements ###/, "require 'net/ssh'")
-              content.gsub!(/### include backend conf ###/, "c.before do
-    host  = File.basename(Pathname.new(example.metadata[:location]).dirname)
+              content.gsub!(/### include backend conf ###/, "c.before :all do
+    file, line = self.class.metadata[:example_group_block].source_location
+    host  = File.basename(Pathname.new(file).dirname)
     if c.host != host
       c.ssh.close if c.ssh
       c.host  = host
@@ -112,7 +113,7 @@ EOF
     end
   end")
             when 'Exec'
-              content.gsub!(/### include backend conf ###/, "c.before do
+              content.gsub!(/### include backend conf ###/, "c.before :all do
     c.os = backend(Serverspec::Commands::Base).check_os
   end")
             when 'Puppet'


### PR DESCRIPTION
- Auto OS detection is default.So you don't need to select OS type.
- Include backend helper in global context, not in RSpec context
  - I'd like to use 'backend' and 'commands' in anywhere in serverspec
- Run before hoos in :all
  - It doesn't need to run in :each
