### PR TITLE
add check_file_contain_within to lib/serverspec/commands/solaris.rb 

### DIFF
--- a/lib/serverspec/commands/solaris.rb
+++ b/lib/serverspec/commands/solaris.rb
@@ -53,6 +53,13 @@ module Serverspec
         end
         commands.join(' && ')
       end
+
+      def check_file_contain_within file, expected_pattern, from=nil, to=nil
+        from ||= '1'
+        to ||= '$'
+        checker = check_file_contain("/dev/stdin", expected_pattern)
+        "sed -n '#{from},#{to}p' #{file} | #{checker}"
+      end
     end
   end
 end

--- a/spec/solaris/commands_spec.rb
+++ b/spec/solaris/commands_spec.rb
@@ -58,22 +58,22 @@ end
 describe 'check_file_contain_within', :os => :solaris do
   context 'contain a pattern in the file' do
     subject { commands.check_file_contain_within('Gemfile', 'rspec') }
-    it { should eq "sed -n '1,$p' Gemfile | grep -q 'rspec' -" }
+    it { should eq "sed -n '1,$p' Gemfile | grep -q 'rspec' /dev/stdin" }
   end
 
   context 'contain a pattern after a line in a file' do
     subject { commands.check_file_contain_within('Gemfile', 'rspec', '/^group :test do/') }
-    it { should eq "sed -n '/^group :test do/,$p' Gemfile | grep -q 'rspec' -" }
+    it { should eq "sed -n '/^group :test do/,$p' Gemfile | grep -q 'rspec' /dev/stdin" }
   end
 
   context 'contain a pattern before a line in a file' do
     subject {commands.check_file_contain_within('Gemfile', 'rspec', nil, '/^end/') }
-    it { should eq "sed -n '1,/^end/p' Gemfile | grep -q 'rspec' -" }
+    it { should eq "sed -n '1,/^end/p' Gemfile | grep -q 'rspec' /dev/stdin" }
   end
 
   context 'contain a pattern from within a line and another line in a file' do
     subject { commands.check_file_contain_within('Gemfile', 'rspec', '/^group :test do/', '/^end/') }
-    it { should eq "sed -n '/^group :test do/,/^end/p' Gemfile | grep -q 'rspec' -" }
+    it { should eq "sed -n '/^group :test do/,/^end/p' Gemfile | grep -q 'rspec' /dev/stdin" }
   end
 end
 


### PR DESCRIPTION
I've added check_file_contain_within to lib/serverspec/commands/solaris.rb to work on Solaris.

Solaris's grep does not accept '-', then use '/dev/stdin' instead of '-'.
