### PR TITLE
add check_belonging_group to lib/serverspec/commands/solaris.rb

### DIFF
--- a/lib/serverspec/commands/solaris.rb
+++ b/lib/serverspec/commands/solaris.rb
@@ -60,6 +60,10 @@ module Serverspec
         checker = check_file_contain("/dev/stdin", expected_pattern)
         "sed -n '#{from},#{to}p' #{file} | #{checker}"
       end
+
+      def check_belonging_group user, group
+        "id -Gn #{user} | grep #{group}"
+      end
     end
   end
 end

--- a/spec/solaris/commands_spec.rb
+++ b/spec/solaris/commands_spec.rb
@@ -109,9 +109,8 @@ end
 
 describe 'check_belonging_group', :os => :solaris do
   subject { commands.check_belonging_group('root', 'wheel') }
-  it { should eq "id root | awk '{print $3}' | grep wheel" }
+  it { should eq "id -Gn root | grep wheel" }
 end
-
 
 describe 'check_zfs', :os => :solaris do
   context 'check without properties' do


### PR DESCRIPTION
I've added check_belonging_group to lib/serverspec/commands/solaris.rb to work on Solaris.

Solaris's 'id' command output is defferent from Linux's,
then use 'id -Gn' on Solaris.
