### PR TITLE
two new matchers "be_mounted" and "be_resolvable"

### DIFF
--- a/lib/serverspec/commands/base.rb
+++ b/lib/serverspec/commands/base.rb
@@ -7,6 +7,20 @@ module Serverspec
         raise NotImplementedError.new
       end
 
+      def check_mounted mount
+        "mountpoint -q #{mount}"
+      end
+
+      def check_resolvable name, type
+        if type == "dns"
+          "nslookup -timeout=1 #{name}"
+        elsif type == "hosts"
+          "grep -w #{name} /etc/hosts"
+        else
+          "getent hosts #{name}"            
+        end
+      end
+
       def check_file file
         "test -f #{file}"
       end

--- a/lib/serverspec/matchers.rb
+++ b/lib/serverspec/matchers.rb
@@ -1,3 +1,5 @@
+require 'serverspec/matchers/be_mounted'
+require 'serverspec/matchers/be_resolvable'
 require 'serverspec/matchers/be_enabled'
 require 'serverspec/matchers/be_file'
 require 'serverspec/matchers/be_directory'

--- a/lib/serverspec/matchers/be_mounted.rb
+++ b/lib/serverspec/matchers/be_mounted.rb
@@ -1,0 +1,5 @@
+RSpec::Matchers.define :be_mounted do
+  match do |actual|
+    backend.check_mounted(example, actual)
+  end
+end

--- a/lib/serverspec/matchers/be_resolvable.rb
+++ b/lib/serverspec/matchers/be_resolvable.rb
@@ -1,0 +1,8 @@
+RSpec::Matchers.define :be_resolvable do
+  match do |actual|
+    backend.check_resolvable(example, actual, @type)
+  end
+  chain :by do |type|
+    @type = type
+  end
+end

--- a/spec/debian/commands_spec.rb
+++ b/spec/debian/commands_spec.rb
@@ -10,6 +10,22 @@ describe 'check_file', :os => :debian  do
   it { should eq 'test -f /etc/passwd' }
 end
 
+describe 'check_mounted', :os => :debian  do
+  subject { commands.check_mounted('/') }
+  it { should eq 'mountpoint -q /' }
+end
+
+describe 'check_resolvable', :os => :debian  do
+  context "resolve localhost by dns" do
+    subject { commands.check_resolvable('localhost', 'hosts') }
+    it { should eq "grep -w localhost /etc/hosts" }
+  end
+  context "resolve localhost with default settings" do
+    subject { commands.check_resolvable('localhost',nil) }
+    it { should eq 'getent hosts localhost' }    
+  end
+end
+
 describe 'check_directory', :os => :debian  do
   subject { commands.check_directory('/var/log') }
   it { should eq 'test -d /var/log' }

--- a/spec/debian/matchers_spec.rb
+++ b/spec/debian/matchers_spec.rb
@@ -7,6 +7,8 @@ describe 'Serverspec matchers of Debian family', :os => :debian do
   it_behaves_like 'support be_running.under("supervisor") matcher', 'growthforecast'
   it_behaves_like 'support be_listening matcher', 22
   it_behaves_like 'support be_file matcher', '/etc/ssh/sshd_config'
+  it_behaves_like 'support be_mounted matcher', '/'
+  it_behaves_like 'support be_resolvable matcher', 'localhost'
   it_behaves_like 'support contain matcher', '/etc/ssh/sshd_config', 'See the sshd_config(5) manpage'
   it_behaves_like 'support contain.from.to matcher', 'Gemfile', 'rspec', /^group :test do/, /^end/
   it_behaves_like 'support contain.after matcher', 'Gemfile', 'rspec', /^group :test do/

--- a/spec/gentoo/commands_spec.rb
+++ b/spec/gentoo/commands_spec.rb
@@ -10,6 +10,22 @@ describe 'check_file', :os => :gentoo do
   it { should eq 'test -f /etc/passwd' }
 end
 
+describe 'check_mounted', :os => :debian  do
+  subject { commands.check_mounted('/') }
+  it { should eq 'mountpoint -q /' }
+end
+
+describe 'check_resolvable', :os => :debian  do
+  context "resolve localhost by dns" do
+    subject { commands.check_resolvable('localhost', 'hosts') }
+    it { should eq "grep -w localhost /etc/hosts" }
+  end
+  context "resolve localhost with default settings" do
+    subject { commands.check_resolvable('localhost',nil) }
+    it { should eq 'getent hosts localhost' }    
+  end
+end
+
 describe 'check_directory', :os => :gentoo do
   subject { commands.check_directory('/var/log') }
   it { should eq 'test -d /var/log' }

--- a/spec/gentoo/matchers_spec.rb
+++ b/spec/gentoo/matchers_spec.rb
@@ -7,6 +7,8 @@ describe 'Serverspec matchers of Gentoo family', :os => :gentoo do
   it_behaves_like 'support be_running.under("supervisor") matcher', 'growthforecast'
   it_behaves_like 'support be_listening matcher', 22
   it_behaves_like 'support be_file matcher', '/etc/ssh/sshd_config'
+  it_behaves_like 'support be_mounted matcher', '/'
+  it_behaves_like 'support be_resolvable matcher', 'localhost'
   it_behaves_like 'support be_directory matcher', '/etc/ssh'
   it_behaves_like 'support contain matcher', '/etc/ssh/sshd_config', 'This is the sshd server system-wide configuration file'
   it_behaves_like 'support contain.from.to matcher', 'Gemfile', 'rspec', /^group :test do/, /^end/

--- a/spec/redhat/commands_spec.rb
+++ b/spec/redhat/commands_spec.rb
@@ -10,6 +10,22 @@ describe 'check_file', :os => :redhat do
   it { should eq 'test -f /etc/passwd' }
 end
 
+describe 'check_mounted', :os => :debian  do
+  subject { commands.check_mounted('/') }
+  it { should eq 'mountpoint -q /' }
+end
+
+describe 'check_resolvable', :os => :debian  do
+  context "resolve localhost by dns" do
+    subject { commands.check_resolvable('localhost', 'hosts') }
+    it { should eq "grep -w localhost /etc/hosts" }
+  end
+  context "resolve localhost with default settings" do
+    subject { commands.check_resolvable('localhost',nil) }
+    it { should eq 'getent hosts localhost' }    
+  end
+end
+
 describe 'check_directory', :os => :redhat do
   subject { commands.check_directory('/var/log') }
   it { should eq 'test -d /var/log' }

--- a/spec/redhat/matchers_spec.rb
+++ b/spec/redhat/matchers_spec.rb
@@ -8,6 +8,8 @@ describe 'Serverspec matchers of Red Hat family', :os => :redhat do
   it_behaves_like 'support be_running.under("not implemented") matcher', 'growthforecast'
   it_behaves_like 'support be_listening matcher', 22
   it_behaves_like 'support be_file matcher', '/etc/ssh/sshd_config'
+  it_behaves_like 'support be_mounted matcher', '/'
+  it_behaves_like 'support be_resolvable matcher', 'localhost'
   it_behaves_like 'support be_directory matcher', '/etc/ssh'
   it_behaves_like 'support contain matcher', '/etc/ssh/sshd_config', 'This is the sshd server system-wide configuration file'
   it_behaves_like 'support contain.from.to matcher', 'Gemfile', 'rspec', /^group :test do/, /^end/

--- a/spec/solaris/commands_spec.rb
+++ b/spec/solaris/commands_spec.rb
@@ -10,6 +10,22 @@ describe 'check_file', :os => :solaris do
   it { should eq 'test -f /etc/passwd' }
 end
 
+describe 'check_mounted', :os => :debian  do
+  subject { commands.check_mounted('/') }
+  it { should eq 'mountpoint -q /' }
+end
+
+describe 'check_resolvable', :os => :debian  do
+  context "resolve localhost by dns" do
+    subject { commands.check_resolvable('localhost', 'hosts') }
+    it { should eq "grep -w localhost /etc/hosts" }
+  end
+  context "resolve localhost with default settings" do
+    subject { commands.check_resolvable('localhost',nil) }
+    it { should eq 'getent hosts localhost' }    
+  end
+end
+
 describe 'check_directory', :os => :solaris do
   subject { commands.check_directory('/var/log') }
   it { should eq 'test -d /var/log' }

--- a/spec/solaris/matchers_spec.rb
+++ b/spec/solaris/matchers_spec.rb
@@ -7,6 +7,8 @@ describe 'Serverspec matchers of Solaris family', :os => :solaris do
   it_behaves_like 'support be_running.under("supervisor") matcher', 'growthforecast'
   it_behaves_like 'support be_listening matcher', 22
   it_behaves_like 'support be_file matcher', '/etc/ssh/sshd_config'
+  it_behaves_like 'support be_mounted matcher', '/'
+  it_behaves_like 'support be_resolvable matcher', 'localhost'
   it_behaves_like 'support be_directory matcher', '/etc/ssh'
   it_behaves_like 'support contain matcher', '/etc/ssh/sshd_config', 'Configuration file for sshd(1m) (see also sshd_config(4))'
   it_behaves_like 'support contain.from.to matcher', 'Gemfile', 'rspec', /^group :test do/, /^end/

--- a/spec/support/shared_matcher_examples.rb
+++ b/spec/support/shared_matcher_examples.rb
@@ -94,6 +94,30 @@ shared_examples_for 'support be_listening matcher' do |valid_port|
   end
 end
 
+shared_examples_for 'support be_mounted matcher' do |valid_mount|
+  describe 'be_mounted' do
+    describe valid_mount do
+      it { should be_mounted }
+    end
+
+    describe '/etc/thid_is_a_invalid_mount' do
+      it { should_not be_mounted }
+    end
+  end
+end
+
+shared_examples_for 'support be_resolvable matcher' do |valid_name|
+  describe 'be_resolvable' do
+    describe valid_name do
+      it { should be_resolvable }
+    end
+
+    describe 'invalid_name' do
+      it { should_not be_resolvable }
+    end
+  end
+end
+
 shared_examples_for 'support be_file matcher' do |valid_file|
   describe 'be_file' do
     describe valid_file do


### PR DESCRIPTION
hello :)

ive been playing around with serverspec today. i really like the idea of test servers with rspec. this is the first github project i contribute to ever and my first ruby project too. ive created two new matchers:
- be_mounted
- be_resolvable

usage example:

``` ruby
describe 'resolv' do
  context "hostA" do
    it { should be_resolvable.by("dns") }
  end
  context "hostB" do
    it { should be_resolvable.by("hosts") }
  end
  context "hostC" do
    # use dns by default
    it { should be_resolvable }
  end
end

describe "/usr/local" do
  it { should be_mounted }
end
```

i hope i have done everything right. thx :smile: 
