### PR TITLE
add check_gid for Solaris

### DIFF
--- a/lib/serverspec/commands/solaris.rb
+++ b/lib/serverspec/commands/solaris.rb
@@ -64,6 +64,10 @@ module Serverspec
       def check_belonging_group user, group
         "id -Gn #{user} | grep #{group}"
       end
+
+      def check_gid group, gid
+        "getent group | grep ^#{group}: | cut -f 3 -d ':' | grep -w #{gid}"
+      end
     end
   end
 end

--- a/spec/solaris/commands_spec.rb
+++ b/spec/solaris/commands_spec.rb
@@ -114,7 +114,7 @@ end
 
 describe 'have_gid', :os => :solaris do
   subject { commands.check_gid('root', 0) }
-  it { should eq "getent group | grep -w ^root | cut -f 3 -d ':' | grep -w 0" }
+  it { should eq "getent group | grep ^root: | cut -f 3 -d ':' | grep -w 0" }
 end
 
 describe 'have_uid', :os => :solaris do


### PR DESCRIPTION
I've added check_gid for Solaris.

"grep -w ^#{group}", 
Solaris's grep does not treat "^#{group}" as "^" and a word "#{group}", 
treat as a word "^#{group}".
