### PR TITLE
change sysctl's path to fullpath (for CentOS5)

### DIFF
--- a/lib/serverspec/filter.rb
+++ b/lib/serverspec/filter.rb
@@ -6,7 +6,7 @@ module Serverspec
       # Linux kernel parameters
       %w( abi crypto debug dev fs kernel net sunrpc vm ).each do |param|
         if description_args.match(/^#{param}\./)
-          ret = backend(Serverspec::Commands::Base).do_check("sysctl -q -n #{description_args}")
+          ret = backend(Serverspec::Commands::Base).do_check("/sbin/sysctl -q -n #{description_args}")
           val = ret[:stdout].strip
           val = val.to_i if val.match(/^\d+$/)
           subject = Serverspec::Subject.new


### PR DESCRIPTION
change sysctl's path to fullpath (for CentOS5)
