### PR TITLE
Add with and only_with chain to be_mounted matcher

### DIFF
--- a/lib/serverspec/commands/base.rb
+++ b/lib/serverspec/commands/base.rb
@@ -7,8 +7,8 @@ module Serverspec
         raise NotImplementedError.new
       end
 
-      def check_mounted mount
-        "mountpoint -q #{mount}"
+      def check_mounted path
+        "mount | grep -w 'on #{path}'"
       end
 
       def check_resolvable name, type

--- a/lib/serverspec/matchers/be_mounted.rb
+++ b/lib/serverspec/matchers/be_mounted.rb
@@ -1,5 +1,13 @@
 RSpec::Matchers.define :be_mounted do
   match do |path|
-    backend.check_mounted(example, path)
+    backend.check_mounted(example, path, @attr, @only_with)
+  end
+  chain :with do |attr|
+    @attr      = attr
+    @only_with = false
+  end
+  chain :only_with do |attr|
+    @attr      = attr
+    @only_with = true
   end
 end

--- a/spec/debian/commands_spec.rb
+++ b/spec/debian/commands_spec.rb
@@ -12,7 +12,7 @@ end
 
 describe 'check_mounted', :os => :debian  do
   subject { commands.check_mounted('/') }
-  it { should eq 'mountpoint -q /' }
+  it { should eq "mount | grep -w 'on /'" }
 end
 
 describe 'check_resolvable', :os => :debian  do

--- a/spec/debian/matchers_spec.rb
+++ b/spec/debian/matchers_spec.rb
@@ -7,7 +7,11 @@ describe 'Serverspec matchers of Debian family', :os => :debian do
   it_behaves_like 'support be_running.under("supervisor") matcher', 'growthforecast'
   it_behaves_like 'support be_listening matcher', 22
   it_behaves_like 'support be_file matcher', '/etc/ssh/sshd_config'
+
   it_behaves_like 'support be_mounted matcher', '/'
+  it_behaves_like 'support be_mounted.with matcher', '/'
+  it_behaves_like 'support be_mounted.only_with matcher', '/'
+
   it_behaves_like 'support be_resolvable matcher', 'localhost'
   it_behaves_like 'support be_resolvable.by matcher', 'localhost', 'hosts'
   it_behaves_like 'support be_resolvable.by matcher', 'localhost', 'dns'

--- a/spec/gentoo/commands_spec.rb
+++ b/spec/gentoo/commands_spec.rb
@@ -12,7 +12,7 @@ end
 
 describe 'check_mounted', :os => :debian  do
   subject { commands.check_mounted('/') }
-  it { should eq 'mountpoint -q /' }
+  it { should eq "mount | grep -w 'on /'" }
 end
 
 describe 'check_resolvable', :os => :debian  do

--- a/spec/gentoo/matchers_spec.rb
+++ b/spec/gentoo/matchers_spec.rb
@@ -7,7 +7,11 @@ describe 'Serverspec matchers of Gentoo family', :os => :gentoo do
   it_behaves_like 'support be_running.under("supervisor") matcher', 'growthforecast'
   it_behaves_like 'support be_listening matcher', 22
   it_behaves_like 'support be_file matcher', '/etc/ssh/sshd_config'
+
   it_behaves_like 'support be_mounted matcher', '/'
+  it_behaves_like 'support be_mounted.with matcher', '/'
+  it_behaves_like 'support be_mounted.only_with matcher', '/'
+
   it_behaves_like 'support be_resolvable matcher', 'localhost'
   it_behaves_like 'support be_resolvable.by matcher', 'localhost', 'hosts'
   it_behaves_like 'support be_resolvable.by matcher', 'localhost', 'dns'

--- a/spec/redhat/commands_spec.rb
+++ b/spec/redhat/commands_spec.rb
@@ -12,7 +12,7 @@ end
 
 describe 'check_mounted', :os => :debian  do
   subject { commands.check_mounted('/') }
-  it { should eq 'mountpoint -q /' }
+  it { should eq "mount | grep -w 'on /'" }
 end
 
 describe 'check_resolvable', :os => :debian  do

--- a/spec/redhat/matchers_spec.rb
+++ b/spec/redhat/matchers_spec.rb
@@ -8,7 +8,11 @@ describe 'Serverspec matchers of Red Hat family', :os => :redhat do
   it_behaves_like 'support be_running.under("not implemented") matcher', 'growthforecast'
   it_behaves_like 'support be_listening matcher', 22
   it_behaves_like 'support be_file matcher', '/etc/ssh/sshd_config'
+
   it_behaves_like 'support be_mounted matcher', '/'
+  it_behaves_like 'support be_mounted.with matcher', '/'
+  it_behaves_like 'support be_mounted.only_with matcher', '/'
+
   it_behaves_like 'support be_resolvable matcher', 'localhost'
   it_behaves_like 'support be_resolvable.by matcher', 'localhost', 'hosts'
   it_behaves_like 'support be_resolvable.by matcher', 'localhost', 'dns'

--- a/spec/solaris/commands_spec.rb
+++ b/spec/solaris/commands_spec.rb
@@ -12,7 +12,7 @@ end
 
 describe 'check_mounted', :os => :debian  do
   subject { commands.check_mounted('/') }
-  it { should eq 'mountpoint -q /' }
+  it { should eq "mount | grep -w 'on /'" }
 end
 
 describe 'check_resolvable', :os => :debian  do

--- a/spec/solaris/matchers_spec.rb
+++ b/spec/solaris/matchers_spec.rb
@@ -7,7 +7,11 @@ describe 'Serverspec matchers of Solaris family', :os => :solaris do
   it_behaves_like 'support be_running.under("supervisor") matcher', 'growthforecast'
   it_behaves_like 'support be_listening matcher', 22
   it_behaves_like 'support be_file matcher', '/etc/ssh/sshd_config'
+
   it_behaves_like 'support be_mounted matcher', '/'
+  it_behaves_like 'support be_mounted.with matcher', '/'
+  it_behaves_like 'support be_mounted.only_with matcher', '/'
+
   it_behaves_like 'support be_resolvable matcher', 'localhost'
   it_behaves_like 'support be_resolvable.by matcher', 'localhost', 'hosts'
   it_behaves_like 'support be_resolvable.by matcher', 'localhost', 'dns'

--- a/spec/support/shared_matcher_examples.rb
+++ b/spec/support/shared_matcher_examples.rb
@@ -106,6 +106,112 @@ shared_examples_for 'support be_mounted matcher' do |valid_mount|
   end
 end
 
+shared_examples_for 'support be_mounted.with matcher' do |valid_mount|
+  describe 'be_mounted.with' do
+    before :all do
+      RSpec.configure do |c|
+        c.stdout = "/dev/mapper/VolGroup-lv_root on / type ext4 (rw,mode=620)\r\n"
+      end
+    end
+
+    describe valid_mount do
+      it { should be_mounted.with( :type => 'ext4' ) }
+    end
+
+    describe valid_mount do
+      it { should be_mounted.with( :type => 'ext4', :options => { :rw => true } ) }
+    end
+
+    describe valid_mount do
+      it { should be_mounted.with( :type => 'ext4', :options => { :mode => 620 } ) }
+    end
+
+    describe valid_mount do
+      it { should_not be_mounted.with( :type => 'xfs' ) }
+    end
+
+    describe valid_mount do
+      it { should_not be_mounted.with( :type => 'ext4', :options => { :rw => false } ) }
+    end
+
+    describe valid_mount do
+      it { should_not be_mounted.with( :type => 'ext4', :options => { :mode => 600 } ) }
+    end
+
+    describe '/etc/thid_is_a_invalid_mount' do
+      it { should_not be_mounted.with( :type => 'ext4' ) }
+    end
+  end
+end
+
+
+shared_examples_for 'support be_mounted.only_with matcher' do |valid_mount|
+  describe 'be_mounted.with' do
+    before :all do
+      RSpec.configure do |c|
+        c.stdout = "/dev/mapper/VolGroup-lv_root on / type ext4 (rw,mode=620)\r\n"
+      end
+    end
+
+    describe valid_mount do
+      it do
+        should be_mounted.only_with(
+          :device  => '/dev/mapper/VolGroup-lv_root',
+          :type    => 'ext4',
+          :options => {
+            :rw   => true,
+            :mode => 620,
+          }
+        )
+      end
+    end
+
+    describe valid_mount do
+      it do
+        should_not be_mounted.only_with(
+          :device  => '/dev/mapper/VolGroup-lv_root',
+          :type    => 'ext4',
+          :options => {
+            :rw   => true,
+            :mode => 620,
+            :bind => true,
+          }
+        )
+      end
+    end
+
+    describe valid_mount do
+      it do
+        should_not be_mounted.only_with(
+          :device  => '/dev/mapper/VolGroup-lv_root',
+          :type    => 'ext4',
+          :options => {
+            :rw   => true,
+          }
+        )
+      end
+    end
+
+    describe valid_mount do
+      it do
+        should_not be_mounted.only_with(
+          :device  => '/dev/mapper/VolGroup-lv_roooooooooot',
+          :type    => 'ext4',
+          :options => {
+            :rw   => true,
+            :mode => 620,
+          }
+        )
+      end
+    end
+
+    describe '/etc/thid_is_a_invalid_mount' do
+      it { should_not be_mounted.only_with( :type => 'ext4' ) }
+    end
+  end
+end
+
+
 shared_examples_for 'support be_resolvable matcher' do |valid_name|
   describe 'be_resolvable' do
     describe valid_name do


### PR DESCRIPTION
With this chain, you can test a given path mounted with correct attributes like this.

``` ruby
describe '/' do
  it { should_not be_mounted.with( :type => 'ext4', :options => { :rw => true } ) }
end

describe valid_mount do
  it do
    should be_mounted.only_with(
      :device  => '/dev/mapper/VolGroup-lv_root',
      :type    => 'ext4',
      :options => {
        :rw   => true,
      }
    )
  end
end
```

`only_with` needs all attributes of the mounted path.
