### PR TITLE
check for described_class before invoking subject

### DIFF
--- a/lib/serverspec.rb
+++ b/lib/serverspec.rb
@@ -24,7 +24,7 @@ RSpec.configure do |c|
   c.add_setting :ssh,           :default => nil
   c.add_setting :sudo_password, :default => nil
   c.before :each do
-    if subject == 'value'
+    if described_class.nil? && subject == 'value'
       def subject
         Serverspec::Filter.filter_subject example
       end


### PR DESCRIPTION
I am opening this pull request as I noticed that if you have some specs using the format below, when you invoke subject, rspec will grab use the `implicit_subject` which tries to instantiate the described class.

``` ruby
class ClassA
  def initialize(an_arg)
  end
end

describe ClassA do
  it { should be_a Class }
end
```

I have added what I think might be a "hack" fix to this issue. In looking at the commit (sha c1a3644a) I am unsure what the use case was for this feature so I'm not sure how to best accurately address the issue.

This fix may actually be valid but at least I wanted to open up the discussion around this.
