### PR TITLE
Detect Darwin for beginning to support OS X.

### DIFF
--- a/lib/serverspec.rb
+++ b/lib/serverspec.rb
@@ -13,12 +13,14 @@ require 'serverspec/commands/redhat'
 require 'serverspec/commands/debian'
 require 'serverspec/commands/gentoo'
 require 'serverspec/commands/solaris'
+require 'serverspec/commands/darwin'
 
 RSpec.configure do |c|
   c.include(Serverspec::Helper::RedHat,  :os => :redhat)
   c.include(Serverspec::Helper::Debian,  :os => :debian)
   c.include(Serverspec::Helper::Gentoo,  :os => :gentoo)
   c.include(Serverspec::Helper::Solaris, :os => :solaris)
+  c.include(Serverspec::Helper::Darwin,  :os => :darwin)
   c.add_setting :os,            :default => nil
   c.add_setting :host,          :default => nil
   c.add_setting :ssh,           :default => nil

--- a/lib/serverspec/backend/exec.rb
+++ b/lib/serverspec/backend/exec.rb
@@ -156,6 +156,8 @@ module Serverspec
           'Gentoo'
         elsif run_command('uname -s')[:stdout] =~ /SunOS/i
           'Solaris'
+        elsif run_command('uname -s')[:stdout] =~ /Darwin/i
+          'Darwin'
         end
       end
 

--- a/lib/serverspec/commands/darwin.rb
+++ b/lib/serverspec/commands/darwin.rb
@@ -1,0 +1,9 @@
+require 'shellwords'
+
+module Serverspec
+  module Commands
+    class Darwin < Base
+      class NotImplementedError < Exception; end
+    end
+  end
+end

--- a/lib/serverspec/helper.rb
+++ b/lib/serverspec/helper.rb
@@ -10,6 +10,7 @@ require 'serverspec/helper/redhat'
 require 'serverspec/helper/debian'
 require 'serverspec/helper/gentoo'
 require 'serverspec/helper/solaris'
+require 'serverspec/helper/darwin'
 require 'serverspec/helper/detect_os'
 
 # Obsoleted helpers

--- a/lib/serverspec/helper/darwin.rb
+++ b/lib/serverspec/helper/darwin.rb
@@ -1,0 +1,9 @@
+module Serverspec
+  module Helper
+    module Darwin
+      def commands
+        Serverspec::Commands::Darin.new
+      end
+    end
+  end
+end

--- a/lib/serverspec/helper/obsoleted.rb
+++ b/lib/serverspec/helper/obsoleted.rb
@@ -59,4 +59,16 @@ module Serverspec
       exit 1
     end
   end
+  module DarwinHelper
+    def self.included(mod)
+      puts
+      puts "**************************************************************"
+      puts "Serverspec::DarwinHelper in spec/spec_helper.rb is deprecated."
+      puts "Use Serverspec::Helper::Darwin instead."
+      puts "Or remove spec/spec_helper.rb and run severspec-init again."
+      puts "**************************************************************"
+      puts
+      exit 1
+    end
+  end
 end


### PR DESCRIPTION
Add detection for Darwin to support running on OS X.
I have tested with OS X Mountain Lion v10.8.3.
