### PR TITLE
Fix match_md5checksum matcher on Darwin (OS X)

### DIFF
--- a/lib/serverspec/commands/darwin.rb
+++ b/lib/serverspec/commands/darwin.rb
@@ -5,6 +5,10 @@ module Serverspec
     class Darwin < Base
       class NotImplementedError < Exception; end
 
+      def check_file_md5checksum file, expected
+        "openssl md5 #{escape(file)} | cut -d'=' -f2 | cut -c 2- | grep -E ^#{escape(expected)}$"
+      end
+
       def check_access_by_user file, user, access
         "sudo -u #{user} -s /bin/test -#{access} #{file}"
       end

--- a/spec/darwin/commands_spec.rb
+++ b/spec/darwin/commands_spec.rb
@@ -102,6 +102,12 @@ describe 'check_file_contain_within', :os => :darwin do
   end
 end
 
+describe 'check_file_md5checksum', :os => :darwin do
+  subject { commands.check_file_md5checksum('/usr/bin/rsync', '03ba2dcdd50ec3a7a45d3900902a83ce') }
+  it { should eq "openssl md5 /usr/bin/rsync | cut -d'=' -f2 | cut -c 2- | grep -E ^03ba2dcdd50ec3a7a45d3900902a83ce$" }
+  it { should_not eq "openssl md5 /usr/bin/rsync | cut -d'=' -f2 | cut -c 2- | grep -E ^03ba2dcdd50ec3a7a45d3900902a83c" }
+end
+
 describe 'check_mode', :os => :darwin do
   subject { commands.check_mode('/etc/sudoers', 440) }
   it { should eq 'stat -c %a /etc/sudoers | grep -- \\^440\\$' }

--- a/spec/darwin/matchers_spec.rb
+++ b/spec/darwin/matchers_spec.rb
@@ -22,6 +22,7 @@ describe 'Serverspec matchers of Darwin', :os => :darwin do
   it_behaves_like 'support contain.from.to matcher', 'Gemfile', 'rspec', /^group :test do/, /^end/
   it_behaves_like 'support contain.after matcher', 'Gemfile', 'rspec', /^group :test do/
   it_behaves_like 'support contain.before matcher', 'Gemfile', 'rspec', /^end/
+  it_behaves_like 'support match_md5checksum matcher', '/usr/bin/rsync', '03ba2dcdd50ec3a7a45d3900902a83ce'
   it_behaves_like 'support be_user matcher', 'root'
   it_behaves_like 'support be_group matcher', 'wheel'
 


### PR DESCRIPTION
Fix match_md5checksum matcher on Darwin because OS X doesn't include md5sum command. This patch works for me on OS X Mountain Lion v10.8.3.
