### PR TITLE
Update gemspec

### DIFF
--- a/serverspec.gemspec
+++ b/serverspec.gemspec
@@ -18,9 +18,9 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "net-ssh"
-  spec.add_dependency "rspec", "~> 2.0.0"
-  spec.add_dependency "highline"
+  spec.add_runtime_dependency "net-ssh"
+  spec.add_runtime_dependency "rspec", "~> 2.0"
+  spec.add_runtime_dependency "highline"
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
Update gemspec because I have confirmed serverspec doesn't support RSpec 1.x now, seems to support RSpec 2.x only.
