### PR TITLE
Explicit linux kernel parameter type

### DIFF
--- a/lib/serverspec/helper/type.rb
+++ b/lib/serverspec/helper/type.rb
@@ -9,6 +9,7 @@ module Serverspec
         file
         cron
         command
+        linux_kernel_parameter
       )
 
       types.each {|type| require "serverspec/type/#{type}" }
@@ -16,8 +17,12 @@ module Serverspec
       types.each do |type|
         define_method type do |*args|
           name = args.first
-          self.class.const_get('Serverspec').const_get('Type').const_get(type.capitalize).new(name)
+          self.class.const_get('Serverspec').const_get('Type').const_get(camelize(type)).new(name)
         end
+      end
+
+      def camelize(string)
+        string.split("_").each {|s| s.capitalize! }.join("")
       end
     end
   end

--- a/lib/serverspec/type/linux_kernel_parameter.rb
+++ b/lib/serverspec/type/linux_kernel_parameter.rb
@@ -1,0 +1,12 @@
+module Serverspec
+  module Type
+    class LinuxKernelParameter < Base
+      def value
+        ret = backend.run_command("/sbin/sysctl -q -n #{@name}")
+        val = ret[:stdout].strip
+        val = val.to_i if val.match(/^\d+$/)
+        val
+      end
+    end
+  end
+end

--- a/spec/debian/linux_kernel_parameter_spec.rb
+++ b/spec/debian/linux_kernel_parameter_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+include Serverspec::Helper::Debian
+
+describe 'Serverspec linux kernel parameter matchers of Debian family' do
+  it_behaves_like 'support explicit linux kernel parameter checking with integer', 'net.ipv4.tcp_syncookies', 1
+  it_behaves_like 'support explicit linux kernel parameter checking with string',  'kernel.osrelease', '2.6.32-131.0.15.el6.x86_64'
+  it_behaves_like 'support explicit linux kernel parameter checking with regexp',  'net.ipv4.tcp_wmem', /4096\t16384\t4194304/
+end

--- a/spec/gentoo/linux_kernel_parameter_spec.rb
+++ b/spec/gentoo/linux_kernel_parameter_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+include Serverspec::Helper::Gentoo
+
+describe 'Serverspec linux kernel parameter matchers of Gentoo family' do
+  it_behaves_like 'support explicit linux kernel parameter checking with integer', 'net.ipv4.tcp_syncookies', 1
+  it_behaves_like 'support explicit linux kernel parameter checking with string',  'kernel.osrelease', '2.6.32-131.0.15.el6.x86_64'
+  it_behaves_like 'support explicit linux kernel parameter checking with regexp',  'net.ipv4.tcp_wmem', /4096\t16384\t4194304/
+end

--- a/spec/redhat/linux_kernel_parameter_spec.rb
+++ b/spec/redhat/linux_kernel_parameter_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+include Serverspec::Helper::RedHat
+
+describe 'Serverspec linux kernel parameter matchers of Red Hat family' do
+  it_behaves_like 'support explicit linux kernel parameter checking with integer', 'net.ipv4.tcp_syncookies', 1
+  it_behaves_like 'support explicit linux kernel parameter checking with string',  'kernel.osrelease', '2.6.32-131.0.15.el6.x86_64'
+  it_behaves_like 'support explicit linux kernel parameter checking with regexp',  'net.ipv4.tcp_wmem', /4096\t16384\t4194304/
+end

--- a/spec/support/shared_linux_kernel_parameter_examples.rb
+++ b/spec/support/shared_linux_kernel_parameter_examples.rb
@@ -1,0 +1,53 @@
+shared_examples_for 'support explicit linux kernel parameter checking with integer' do |param, value|
+  describe 'linux kernel parameter' do
+    before :all do
+      RSpec.configure do |c|
+        c.stdout = "#{value}\n"
+      end
+    end
+
+    context linux_kernel_parameter(param) do
+      its(:value) { should eq value }
+    end
+
+    context linux_kernel_parameter(param) do
+      its(:value) { should_not eq value + 1 }
+    end
+  end
+end
+
+shared_examples_for 'support explicit linux kernel parameter checking with string' do |param, value|
+  describe 'linux kernel parameter' do
+    before :all do
+      RSpec.configure do |c|
+        c.stdout = "#{value}\n"
+      end
+    end
+
+    context linux_kernel_parameter(param) do
+      its(:value) { should eq value }
+    end
+
+    context linux_kernel_parameter(param) do
+      its(:value) { should_not eq value + '_suffix' }
+    end
+  end
+end
+
+shared_examples_for 'support explicit linux kernel parameter checking with regexp' do |param, regexp|
+  describe 'linux kernel parameter' do
+    before :all do
+      RSpec.configure do |c|
+        c.stdout = "4096	16384	4194304\n"
+      end
+    end
+
+    context linux_kernel_parameter(param) do
+      its(:value) { should match regexp }
+    end
+
+    context linux_kernel_parameter(param) do
+      its(:value) { should_not match /invalid-string/ }
+    end
+  end
+end


### PR DESCRIPTION
With this pull request, you can write spec like this:

``` ruby
describe linux_kernel_parameter('net.ipv4.tcp_syncookies') do
  its(:value) { should eq 1 }
end
```
