### PR TITLE
Explicit iptables subject type

### DIFF
--- a/lib/serverspec/helper/type.rb
+++ b/lib/serverspec/helper/type.rb
@@ -1,16 +1,7 @@
 module Serverspec
   module Helper
     module Type
-      types = %w(
-        base
-        service
-        package
-        port
-        file
-        cron
-        command
-        linux_kernel_parameter
-      )
+      types = %w( base service package port file cron command linux_kernel_parameter iptables )
 
       types.each {|type| require "serverspec/type/#{type}" }
 

--- a/lib/serverspec/matchers.rb
+++ b/lib/serverspec/matchers.rb
@@ -40,3 +40,5 @@ require 'serverspec/matchers/return_exit_status'
 require 'serverspec/matchers/return_stdout'
 require 'serverspec/matchers/return_stderr'
 require 'serverspec/matchers/match_md5checksum'
+
+require 'serverspec/matchers/have_rule'

--- a/lib/serverspec/matchers/have_rule.rb
+++ b/lib/serverspec/matchers/have_rule.rb
@@ -1,0 +1,11 @@
+RSpec::Matchers.define :have_rule do |rule|
+  match do |iptables|
+    iptables.has_rule?(rule, @table, @chain)
+  end
+  chain :with_table do |table|
+    @table = table
+  end
+  chain :with_chain do |chain|
+    @chain = chain
+  end
+end

--- a/lib/serverspec/type/iptables.rb
+++ b/lib/serverspec/type/iptables.rb
@@ -1,0 +1,12 @@
+module Serverspec
+  module Type
+    class Iptables < Base
+      def has_rule?(rule, table, chain)
+        backend.check_iptables_rule(nil, rule, table, chain)
+      end
+      def to_s
+        'iptables'
+      end
+    end
+  end
+end

--- a/spec/debian/iptables_spec.rb
+++ b/spec/debian/iptables_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+include Serverspec::Helper::Debian
+
+describe 'Serverspec iptables matchers of Debian family' do
+  it_behaves_like 'support iptables have_rule matcher', '-P INPUT ACCEPT'
+  it_behaves_like 'support iptables have_rule with_table and with_chain matcher', '-P INPUT ACCEPT', 'mangle', 'INPUT'
+end

--- a/spec/gentoo/iptables_spec.rb
+++ b/spec/gentoo/iptables_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+include Serverspec::Helper::Gentoo
+
+describe 'Serverspec iptables matchers of Gentoo family' do
+  it_behaves_like 'support iptables have_rule matcher', '-P INPUT ACCEPT'
+  it_behaves_like 'support iptables have_rule with_table and with_chain matcher', '-P INPUT ACCEPT', 'mangle', 'INPUT'
+end

--- a/spec/redhat/iptables_spec.rb
+++ b/spec/redhat/iptables_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+include Serverspec::Helper::RedHat
+
+describe 'Serverspec iptables matchers of Red Hat family' do
+  it_behaves_like 'support iptables have_rule matcher', '-P INPUT ACCEPT'
+  it_behaves_like 'support iptables have_rule with_table and with_chain matcher', '-P INPUT ACCEPT', 'mangle', 'INPUT'
+end

--- a/spec/support/shared_iptables_examples.rb
+++ b/spec/support/shared_iptables_examples.rb
@@ -1,0 +1,23 @@
+shared_examples_for 'support iptables have_rule matcher' do |rule|
+  describe 'have_rule' do
+    describe iptables do
+      it { should have_rule rule }
+    end
+
+    describe iptables do
+      it { should_not have_rule 'invalid-rule' }
+    end
+  end
+end
+
+shared_examples_for 'support iptables have_rule with_table and with_chain matcher' do |rule, table, chain|
+  describe 'have_rule with_table and with_chain' do
+    describe iptables do
+      it { should have_iptables_rule(rule).with_table(table).with_chain(chain) }
+    end
+
+    describe iptables do
+      it { should_not have_iptables_rule('invalid-rule').with_table(table).with_chain(chain) }
+    end
+  end
+end


### PR DESCRIPTION
With this pull request, you can write spec like this:

``` ruby
describe iptables do
  it { should have_rule('-P INPUT ACCEPT') }
end
```
