### PR TITLE
Explicit host subject type

### DIFF
--- a/lib/serverspec/helper/type.rb
+++ b/lib/serverspec/helper/type.rb
@@ -1,7 +1,7 @@
 module Serverspec
   module Helper
     module Type
-      types = %w( base service package port file cron command linux_kernel_parameter iptables )
+      types = %w( base service package port file cron command linux_kernel_parameter iptables host )
 
       types.each {|type| require "serverspec/type/#{type}" }
 

--- a/lib/serverspec/matchers/be_reachable.rb
+++ b/lib/serverspec/matchers/be_reachable.rb
@@ -8,10 +8,15 @@ RSpec::Matchers.define :be_reachable  do
       timeout = @attr[:timeout] if @attr[:timeout]
     end
 
-    backend.check_reachable(example, host, port, proto, timeout)
+    if host.respond_to?(:reachable?)
+      host.reachable?(port, proto, timeout)
+    else
+      backend.check_reachable(example, host, port, proto, timeout)
+    end
   end
 
   chain :with do |attr|
     @attr = attr
   end
 end
+

--- a/lib/serverspec/matchers/be_resolvable.rb
+++ b/lib/serverspec/matchers/be_resolvable.rb
@@ -1,8 +1,13 @@
 RSpec::Matchers.define :be_resolvable do
   match do |name|
-    backend.check_resolvable(example, name, @type)
+    if name.respond_to?(:resolvable?)
+      name.resolvable?(@type)
+    else
+      backend.check_resolvable(example, name, @type)
+    end
   end
   chain :by do |type|
     @type = type
   end
 end
+

--- a/lib/serverspec/type/host.rb
+++ b/lib/serverspec/type/host.rb
@@ -1,0 +1,13 @@
+module Serverspec
+  module Type
+    class Host < Base
+      def resolvable?(type)
+        backend.check_resolvable(nil, @name, type)
+      end
+
+      def reachable?(port, proto, timeout)
+        backend.check_reachable(nil, @name, port, proto, timeout)
+      end
+    end
+  end
+end

--- a/spec/darwin/host_spec.rb
+++ b/spec/darwin/host_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+include Serverspec::Helper::Darwin
+
+describe 'Serverspec host matchers of Darwin family' do
+  it_behaves_like 'support host be_reachable matcher', '127.0.0.1'
+  it_behaves_like 'support host be_reachable with matcher', '127.0.0.1'
+
+  it_behaves_like 'support host be_resolvable matcher', 'localhost'
+  it_behaves_like 'support host be_resolvable by matcher', 'localhost', 'hosts'
+  it_behaves_like 'support host be_resolvable by matcher', 'localhost', 'dns'
+end

--- a/spec/debian/host_spec.rb
+++ b/spec/debian/host_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+include Serverspec::Helper::Debian
+
+describe 'Serverspec host matchers of Debian family' do
+  it_behaves_like 'support host be_reachable matcher', '127.0.0.1'
+  it_behaves_like 'support host be_reachable with matcher', '127.0.0.1'
+
+  it_behaves_like 'support host be_resolvable matcher', 'localhost'
+  it_behaves_like 'support host be_resolvable by matcher', 'localhost', 'hosts'
+  it_behaves_like 'support host be_resolvable by matcher', 'localhost', 'dns'
+end

--- a/spec/gentoo/host_spec.rb
+++ b/spec/gentoo/host_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+include Serverspec::Helper::Gentoo
+
+describe 'Serverspec host matchers of Gentoo family' do
+  it_behaves_like 'support host be_reachable matcher', '127.0.0.1'
+  it_behaves_like 'support host be_reachable with matcher', '127.0.0.1'
+
+  it_behaves_like 'support host be_resolvable matcher', 'localhost'
+  it_behaves_like 'support host be_resolvable by matcher', 'localhost', 'hosts'
+  it_behaves_like 'support host be_resolvable by matcher', 'localhost', 'dns'
+end

--- a/spec/redhat/host_spec.rb
+++ b/spec/redhat/host_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+include Serverspec::Helper::RedHat
+
+describe 'Serverspec host matchers of Red Hat family' do
+  it_behaves_like 'support host be_reachable matcher', '127.0.0.1'
+  it_behaves_like 'support host be_reachable with matcher', '127.0.0.1'
+
+  it_behaves_like 'support host be_resolvable matcher', 'localhost'
+  it_behaves_like 'support host be_resolvable by matcher', 'localhost', 'hosts'
+  it_behaves_like 'support host be_resolvable by matcher', 'localhost', 'dns'
+end

--- a/spec/solaris/host_spec.rb
+++ b/spec/solaris/host_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+include Serverspec::Helper::Solaris
+
+describe 'Serverspec host matchers of Solaris family' do
+  it_behaves_like 'support host be_reachable matcher', '127.0.0.1'
+  it_behaves_like 'support host be_reachable with matcher', '127.0.0.1'
+
+  it_behaves_like 'support host be_resolvable matcher', 'localhost'
+  it_behaves_like 'support host be_resolvable by matcher', 'localhost', 'hosts'
+  it_behaves_like 'support host be_resolvable by matcher', 'localhost', 'dns'
+end

--- a/spec/support/shared_host_examples.rb
+++ b/spec/support/shared_host_examples.rb
@@ -1,0 +1,53 @@
+shared_examples_for 'support host be_resolvable matcher' do |name|
+  describe 'be_resolvable' do
+    describe host(name) do
+      it { should be_resolvable }
+    end
+
+    describe host('invalid-name') do
+      it { should_not be_resolvable }
+    end
+  end
+end
+
+
+shared_examples_for 'support host be_resolvable by matcher' do |name, type|
+  describe 'be_resolvable.by' do
+    describe host(name) do
+      it { should be_resolvable.by(type) }
+    end
+
+    describe host('invalid-name') do
+      it { should_not be_resolvable.by(type) }
+    end
+  end
+end
+
+shared_examples_for 'support host be_reachable matcher' do |name|
+  describe 'be_reachable' do
+    context host(name) do
+      it { should be_reachable }
+    end
+
+    describe host('invalid-host') do
+      it { should_not be_reachable }
+    end
+  end
+end
+
+shared_examples_for 'support host be_reachable with matcher' do |name|
+  describe 'be_reachable.with' do
+    context host(name) do
+      it { should be_reachable.with(:proto => "icmp", :timeout=> 1) }
+    end
+    context host(name) do
+      it { should be_reachable.with(:proto => "tcp", :port => 22, :timeout=> 1) }
+    end
+    context host(name) do
+      it { should be_reachable.with(:proto => "udp", :port => 53, :timeout=> 1) }
+    end
+    context host('invalid-host') do
+      it { should_not be_reachable.with(:proto => "udp", :port => 53, :timeout=> 1) }
+    end
+  end
+end


### PR DESCRIPTION
With this pull request, you can write spec like this:

``` ruby
describe host('serverspec.org') do
  it { should be_resolvable }
  it { should be_reachable }
end
```
