### PR TITLE
Explicit routing table subject type

### DIFF
--- a/lib/serverspec/helper/type.rb
+++ b/lib/serverspec/helper/type.rb
@@ -1,7 +1,10 @@
 module Serverspec
   module Helper
     module Type
-      types = %w( base service package port file cron command linux_kernel_parameter iptables host )
+      types = %w(
+        base service package port file cron command linux_kernel_parameter iptables host
+        routing_table
+      )
 
       types.each {|type| require "serverspec/type/#{type}" }
 

--- a/lib/serverspec/matchers/have_entry.rb
+++ b/lib/serverspec/matchers/have_entry.rb
@@ -2,6 +2,8 @@ RSpec::Matchers.define :have_entry do |entry|
   match do |subject|
     if subject.class.name == 'Serverspec::Type::Cron'
        subject.has_entry?(@user, entry)
+    elsif subject.respond_to?(:has_entry?)
+      subject.has_entry?(entry)
     else
       backend.check_routing_table(example, entry)
     end

--- a/lib/serverspec/type/routing_table.rb
+++ b/lib/serverspec/type/routing_table.rb
@@ -1,0 +1,13 @@
+module Serverspec
+  module Type
+    class RoutingTable < Base
+      def has_entry?(entry)
+        backend.check_routing_table(nil, entry)
+      end
+
+      def to_s
+        'Routing table'
+      end
+    end
+  end
+end

--- a/spec/darwin/routing_table_spec.rb
+++ b/spec/darwin/routing_table_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+include Serverspec::Helper::Darwin
+
+describe 'Serverspec routing table matchers of Darwin family' do
+  it_behaves_like 'support routing table have_entry matcher'
+end

--- a/spec/debian/routing_table_spec.rb
+++ b/spec/debian/routing_table_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+include Serverspec::Helper::Debian
+
+describe 'Serverspec routing table matchers of Debian family' do
+  it_behaves_like 'support routing table have_entry matcher'
+end

--- a/spec/redhat/routing_table_spec.rb
+++ b/spec/redhat/routing_table_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+include Serverspec::Helper::RedHat
+
+describe 'Serverspec routing table matchers of Red Hat family' do
+  it_behaves_like 'support routing table have_entry matcher'
+end

--- a/spec/solaris/routing_table_spec.rb
+++ b/spec/solaris/routing_table_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+include Serverspec::Helper::Solaris
+
+describe 'Serverspec routing table matchers of Solaris family' do
+  it_behaves_like 'support routing table have_entry matcher'
+end

--- a/spec/support/shared_routing_table_examples.rb
+++ b/spec/support/shared_routing_table_examples.rb
@@ -1,0 +1,130 @@
+shared_examples_for 'support routing table have_entry matcher' do
+  describe 'routing table have_entry pattern #1' do
+    before :all do
+      RSpec.configure do |c|
+          c.stdout = "192.168.100.0/24 dev eth1  proto kernel  scope link  src 192.168.100.10 \r\ndefault via 192.168.100.1 dev eth0 \r\n"
+      end
+    end
+
+    context routing_table do
+      it { should     have_entry( :destination => '192.168.100.0/24' ) }
+      it { should_not have_entry( :destination => '192.168.100.100/24' ) }
+
+      it do
+        should have_entry(
+          :destination => '192.168.100.0/24',
+          :gateway     => '192.168.100.1'
+        )
+      end
+
+      it do
+        should have_entry(
+          :destination => '192.168.100.0/24',
+          :gateway     => '192.168.100.1',
+          :interface   => 'eth1'
+        )
+      end
+
+      it do
+        should_not have_entry(
+          :gateway   => '192.168.100.1',
+          :interface => 'eth1'
+        )
+      end
+
+      it do
+        should_not have_entry(
+          :destination => '192.168.100.0/32',
+          :gateway     => '192.168.100.1',
+          :interface   => 'eth1'
+        )
+      end
+    end
+  end
+
+  describe 'routing table have_entry pattern #2' do
+    before :all do
+      RSpec.configure do |c|
+          c.stdout = "192.168.200.0/24 via 192.168.200.1 dev eth0 \r\ndefault via 192.168.100.1 dev eth0 \r\n"
+      end
+    end
+
+    context routing_table do
+      it { should     have_entry( :destination => '192.168.200.0/24' ) }
+      it { should_not have_entry( :destination => '192.168.200.200/24' ) }
+
+      it do
+        should have_entry(
+          :destination => '192.168.200.0/24',
+          :gateway     => '192.168.200.1'
+        )
+      end
+
+      it do
+        should have_entry(
+          :destination => '192.168.200.0/24',
+          :gateway     => '192.168.200.1',
+          :interface   => 'eth0'
+        )
+      end
+
+      it do
+        should_not have_entry(
+          :gateway     => '192.168.200.1',
+          :interface   => 'eth0'
+        )
+      end
+
+      it do
+        should_not have_entry(
+          :destination => '192.168.200.0/32',
+          :gateway     => '192.168.200.1',
+          :interface   => 'eth0'
+        )
+      end
+    end
+  end
+
+  describe 'routing table have_entry #3' do
+    before :all do
+      RSpec.configure do |c|
+          c.stdout = "default via 10.0.2.2 dev eth0 \r\n"
+      end
+    end
+
+    context routing_table do
+      it { should     have_entry( :destination => 'default' ) }
+      it { should_not have_entry( :destination => 'defaulth' ) }
+
+      it do
+        should have_entry(
+          :destination => 'default',
+          :gateway     => '10.0.2.2'
+        )
+      end
+
+      it do
+        should have_entry(
+          :destination => 'default',
+          :gateway     => '10.0.2.2',
+          :interface   => 'eth0'
+        )
+      end
+
+      it do
+        should_not have_entry(
+          :gateway     => '10.0.2.2',
+          :interface   => 'eth0'
+        )
+      end
+
+      it do
+        should_not have_entry(
+          :destination => 'default',
+          :gateway     => '10.0.2.1',
+          :interface   => 'eth0'
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
With this pull request, you can write spec like this:

``` ruby
describe routing_table do
  it do
    should have_entry(
      :destination => 'default',
      :interface   => 'br0',
      :gateway     => '192.168.10.1'
    )
  end
end
```
