### PR TITLE
Explicit default gateway subject type

### DIFF
--- a/lib/serverspec/helper/type.rb
+++ b/lib/serverspec/helper/type.rb
@@ -3,7 +3,7 @@ module Serverspec
     module Type
       types = %w(
         base service package port file cron command linux_kernel_parameter iptables host
-        routing_table
+        routing_table default_gateway
       )
 
       types.each {|type| require "serverspec/type/#{type}" }

--- a/lib/serverspec/type/default_gateway.rb
+++ b/lib/serverspec/type/default_gateway.rb
@@ -1,0 +1,21 @@
+module Serverspec
+  module Type
+    class DefaultGateway < Base
+      def ipaddress
+        ret = backend.run_command(commands.check_routing_table('default'))
+        ret[:stdout] =~ /^(\S+)(?: via (\S+))? dev (\S+).+\r\n(?:default via (\S+))?/
+        $2 ? $2 : $4
+      end
+
+      def interface
+        ret = backend.run_command(commands.check_routing_table('default'))
+        ret[:stdout] =~ /^(\S+)(?: via (\S+))? dev (\S+).+\r\n(?:default via (\S+))?/
+        $3
+      end
+
+      def to_s
+        'Default Gateway'
+      end
+    end
+  end
+end

--- a/lib/serverspec/type/routing_table.rb
+++ b/lib/serverspec/type/routing_table.rb
@@ -6,7 +6,7 @@ module Serverspec
       end
 
       def to_s
-        'Routing table'
+        'Routing Table'
       end
     end
   end

--- a/spec/darwin/default_gateway_spec.rb
+++ b/spec/darwin/default_gateway_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+include Serverspec::Helper::Darwin
+
+describe 'Serverspec default gateway matchers of Darwin family' do
+  it_behaves_like 'support default gateway matcher'
+end

--- a/spec/debian/default_gateway_spec.rb
+++ b/spec/debian/default_gateway_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+include Serverspec::Helper::Debian
+
+describe 'Serverspec default gateway matchers of Debian family' do
+  it_behaves_like 'support default gateway matcher'
+end

--- a/spec/gentoo/default_gateway_spec.rb
+++ b/spec/gentoo/default_gateway_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+include Serverspec::Helper::Gentoo
+
+describe 'Serverspec default gateway matchers of Gentoo family' do
+  it_behaves_like 'support default gateway matcher'
+end

--- a/spec/redhat/default_gateway_spec.rb
+++ b/spec/redhat/default_gateway_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+include Serverspec::Helper::RedHat
+
+describe 'Serverspec default gateway matchers of Red Hat family' do
+  it_behaves_like 'support default gateway matcher'
+end

--- a/spec/solaris/default_gateway_spec.rb
+++ b/spec/solaris/default_gateway_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+include Serverspec::Helper::Solaris
+
+describe 'Serverspec default gateway matchers of Solaris family' do
+  it_behaves_like 'support default gateway matcher'
+end

--- a/spec/support/shared_default_gateway_examples.rb
+++ b/spec/support/shared_default_gateway_examples.rb
@@ -1,0 +1,17 @@
+shared_examples_for 'support default gateway matcher' do
+  describe 'default_gateway' do
+    before :all do
+      RSpec.configure do |c|
+        c.stdout = "default via 192.168.1.1 dev eth1 \r\n"
+      end
+    end
+
+    describe default_gateway do
+      its(:ipaddress) { should eq '192.168.1.1' }
+      its(:interface) { should eq 'eth1'        }
+
+      its(:ipaddress) { should_not eq '192.168.1.2' }
+      its(:interface) { should_not eq 'eth0'        }
+    end
+  end
+end


### PR DESCRIPTION
With this pull request, you can write spec like this:

``` ruby
describe default_gateway do
  its(:ipaddress) { should eq '192.168.10.1' }
  its(:interface) { should eq 'br0'          }
end
```
