### PR TITLE
Explicit selinux subject type

### DIFF
--- a/lib/serverspec/helper/type.rb
+++ b/lib/serverspec/helper/type.rb
@@ -3,7 +3,7 @@ module Serverspec
     module Type
       types = %w(
         base service package port file cron command linux_kernel_parameter iptables host
-        routing_table default_gateway
+        routing_table default_gateway selinux
       )
 
       types.each {|type| require "serverspec/type/#{type}" }

--- a/lib/serverspec/matchers/be_disabled.rb
+++ b/lib/serverspec/matchers/be_disabled.rb
@@ -1,5 +1,9 @@
 RSpec::Matchers.define :be_disabled do
-  match do |actual|
-    backend.check_selinux(example, 'disabled')
+  match do |subject|
+    if subject.respond_to?(:disabled?)
+      subject.disabled?
+    else
+      backend.check_selinux(example, 'disabled')
+    end
   end
 end

--- a/lib/serverspec/matchers/be_enforcing.rb
+++ b/lib/serverspec/matchers/be_enforcing.rb
@@ -1,5 +1,10 @@
 RSpec::Matchers.define :be_enforcing do
   match do |actual|
-    backend.check_selinux(example, 'enforcing')
+    if subject.respond_to?(:enforcing?)
+      subject.enforcing?
+    else
+      backend.check_selinux(example, 'enforcing')
+    end
   end
 end
+

--- a/lib/serverspec/matchers/be_permissive.rb
+++ b/lib/serverspec/matchers/be_permissive.rb
@@ -1,5 +1,10 @@
 RSpec::Matchers.define :be_permissive do
   match do |actual|
-    backend.check_selinux(example, 'permissive')
+    if subject.respond_to?(:permissive?)
+      subject.permissive?
+    else
+      backend.check_selinux(example, 'permissive')
+    end
   end
 end
+

--- a/lib/serverspec/type/selinux.rb
+++ b/lib/serverspec/type/selinux.rb
@@ -1,0 +1,21 @@
+module Serverspec
+  module Type
+    class Selinux < Base
+      def disabled?
+        backend.check_selinux(nil, 'disabled')
+      end
+
+      def enforcing?
+        backend.check_selinux(nil, 'enforcing')
+      end
+
+      def permissive?
+        backend.check_selinux(nil, 'permissive')
+      end
+
+      def to_s
+        'SELinux'
+      end
+    end
+  end
+end

--- a/spec/debian/selinux_spec.rb
+++ b/spec/debian/selinux_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+include Serverspec::Helper::Debian
+
+describe 'Serverspec selinux matchers of Debian family' do
+  it_behaves_like 'support selinux be_enforcing matcher'
+  it_behaves_like 'support selinux be_permissive matcher'
+  it_behaves_like 'support selinux be_disabled matcher'
+end

--- a/spec/gentoo/commands_spec.rb
+++ b/spec/gentoo/commands_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+include Serverspec::Helper::Gentoo
+
 describe 'check_enabled' do
   subject { commands.check_enabled('httpd') }
   it { should eq "/sbin/rc-update show | grep -- \\^\\\\s\\*httpd\\\\s\\*\\|\\\\s\\*\\\\\\(boot\\\\\\|default\\\\\\)" }

--- a/spec/gentoo/selinux_spec.rb
+++ b/spec/gentoo/selinux_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+include Serverspec::Helper::Gentoo
+
+describe 'Serverspec selinux matchers of Gentoo family' do
+  it_behaves_like 'support selinux be_enforcing matcher'
+  it_behaves_like 'support selinux be_permissive matcher'
+  it_behaves_like 'support selinux be_disabled matcher'
+end

--- a/spec/redhat/selinux_spec.rb
+++ b/spec/redhat/selinux_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+include Serverspec::Helper::RedHat
+
+describe 'Serverspec selinux matchers of Red Hat family' do
+  it_behaves_like 'support selinux be_enforcing matcher'
+  it_behaves_like 'support selinux be_permissive matcher'
+  it_behaves_like 'support selinux be_disabled matcher'
+end

--- a/spec/support/shared_selinux_examples.rb
+++ b/spec/support/shared_selinux_examples.rb
@@ -1,0 +1,17 @@
+shared_examples_for 'support selinux be_enforcing matcher' do
+  describe selinux do
+    it { should be_enforcing }
+  end
+end
+
+shared_examples_for 'support selinux be_permissive matcher' do
+  describe selinux do
+    it { should be_permissive }
+  end
+end
+
+shared_examples_for 'support selinux be_disabled matcher' do
+  describe selinux do
+    it { should be_disabled }
+  end
+end


### PR DESCRIPTION
With this pull request, you can write spec like this:

``` ruby
describe selinux do
  it { should be_permissive }
end
```
