### PR TITLE
Explicit zfs subject type

### DIFF
--- a/lib/serverspec/helper/type.rb
+++ b/lib/serverspec/helper/type.rb
@@ -3,7 +3,7 @@ module Serverspec
     module Type
       types = %w(
         base service package port file cron command linux_kernel_parameter iptables host
-        routing_table default_gateway selinux user group
+        routing_table default_gateway selinux user group zfs
       )
 
       types.each {|type| require "serverspec/type/#{type}" }

--- a/lib/serverspec/matchers.rb
+++ b/lib/serverspec/matchers.rb
@@ -41,4 +41,6 @@ require 'serverspec/matchers/return_stdout'
 require 'serverspec/matchers/return_stderr'
 require 'serverspec/matchers/match_md5checksum'
 
+# For explicit types
 require 'serverspec/matchers/have_rule'
+

--- a/lib/serverspec/type/zfs.rb
+++ b/lib/serverspec/type/zfs.rb
@@ -1,0 +1,17 @@
+module Serverspec
+  module Type
+    class Zfs < Base
+      def exists?
+        backend.check_zfs(nil, @name)
+      end
+
+      def has_property?(property)
+        backend.check_zfs(nil, @name, property)
+      end
+
+      def to_s
+        'ZFS'
+      end
+    end
+  end
+end

--- a/spec/solaris/zfs_spec.rb
+++ b/spec/solaris/zfs_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+include Serverspec::Helper::Solaris
+
+describe zfs('rpool') do
+  it { should exist }
+  it { should have_property 'mountpoint' => '/rpool'  }
+  it { should have_property 'mountpoint' => '/rpool', 'compression' => 'off' }
+end


### PR DESCRIPTION
With this pull request, you can write spec like this.

``` ruby
describe zfs('rpool') do
  it { should exist }
  it { should have_property 'mountpoint' => '/rpool'  }
  it { should have_property 'mountpoint' => '/rpool', 'compression' => 'off' }
end
```
