### PR TITLE
Explcit ipnat subject type

### DIFF
--- a/lib/serverspec/helper/type.rb
+++ b/lib/serverspec/helper/type.rb
@@ -3,7 +3,7 @@ module Serverspec
     module Type
       types = %w(
         base service package port file cron command linux_kernel_parameter iptables host
-        routing_table default_gateway selinux user group zfs
+        routing_table default_gateway selinux user group zfs ipnat
       )
 
       types.each {|type| require "serverspec/type/#{type}" }

--- a/lib/serverspec/matchers/have_rule.rb
+++ b/lib/serverspec/matchers/have_rule.rb
@@ -1,6 +1,10 @@
 RSpec::Matchers.define :have_rule do |rule|
-  match do |iptables|
-    iptables.has_rule?(rule, @table, @chain)
+  match do |subject|
+    if subject.class.name == 'Serverspec::Type::Iptables'
+      subject.has_rule?(rule, @table, @chain)
+    elsif subject.class.name == 'Serverspec::Type::Ipnat'
+      subject.has_rule?(rule)
+    end
   end
   chain :with_table do |table|
     @table = table

--- a/lib/serverspec/type/ipnat.rb
+++ b/lib/serverspec/type/ipnat.rb
@@ -1,0 +1,13 @@
+module Serverspec
+  module Type
+    class Ipnat < Base
+      def has_rule?(rule)
+        backend.check_ipnat_rule(nil, rule)
+      end
+
+      def to_s
+        'ipnat'
+      end
+    end
+  end
+end

--- a/spec/solaris/ipnat_spec.rb
+++ b/spec/solaris/ipnat_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+include Serverspec::Helper::Solaris
+
+describe ipnat do
+  it { should have_rule 'map net1 192.168.0.0/24 -> 0.0.0.0/32' }
+end


### PR DESCRIPTION
With this pull request, you can write spec like this:

``` ruby
describe ipnat do
  it { should have_rule 'map net1 192.168.0.0/24 -> 0.0.0.0/32' }
end
```
