### PR TITLE
Support have_property with service type

### DIFF
--- a/lib/serverspec/type/service.rb
+++ b/lib/serverspec/type/service.rb
@@ -18,6 +18,10 @@ module Serverspec
           backend.check_running(nil, @name)
         end
       end
+
+      def has_property?(property)
+        backend.check_svcprops(nil, @name, property)
+      end
     end
   end
 end

--- a/spec/solaris/svcprop_spec.rb
+++ b/spec/solaris/svcprop_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+include Serverspec::Helper::Solaris
+
+describe service('svc:/network/http:apache22') do
+  it { should have_property 'httpd/enable_64bit' => false }
+  it { should have_property 'httpd/enable_64bit' => false, 'httpd/server_type'  => 'worker' }
+end


### PR DESCRIPTION
With this pull request, you can write spec like this.

``` ruby
describe service('svc:/network/http:apache22') do
  it { should have_property 'httpd/enable_64bit' => false }
  it { should have_property 'httpd/enable_64bit' => false, 'httpd/server_type'  => 'worker' }
end
```
