### PR TITLE
Specify the absolute path of /sbin commands

### DIFF
--- a/lib/serverspec/commands/base.rb
+++ b/lib/serverspec/commands/base.rb
@@ -19,7 +19,7 @@ module Serverspec
       end
 
       def check_routing_table destination
-        "ip route | grep -E '^#{destination} |^default '"
+        "/sbin/ip route | grep -E '^#{destination} |^default '"
       end
 
       def check_reachable host, port, proto, timeout
@@ -66,7 +66,7 @@ module Serverspec
       end
 
       def check_running service
-        "service #{escape(service)} status"
+        "/sbin/service #{escape(service)} status"
       end
 
       def check_running_under_supervisor service

--- a/lib/serverspec/commands/linux.rb
+++ b/lib/serverspec/commands/linux.rb
@@ -10,7 +10,7 @@ module Serverspec
       end
 
       def check_iptables_rule rule, table=nil, chain=nil
-        cmd = "iptables"
+        cmd = "/sbin/iptables"
         cmd += " -t #{escape(table)}" if table
         cmd += " -S"
         cmd += " #{escape(chain)}" if chain

--- a/lib/serverspec/commands/redhat.rb
+++ b/lib/serverspec/commands/redhat.rb
@@ -3,11 +3,11 @@ module Serverspec
     class RedHat < Linux
       def check_access_by_user file, user, access
         # Redhat-specific
-        "runuser -s /bin/sh -c \"test -#{access} #{file}\" #{user}"
+        "/sbin/runuser -s /bin/sh -c \"test -#{access} #{file}\" #{user}"
       end
 
       def check_enabled service
-        "chkconfig --list #{escape(service)} | grep 3:on"
+        "/sbin/chkconfig --list #{escape(service)} | grep 3:on"
       end
 
       def check_installed package

--- a/spec/darwin/commands_spec.rb
+++ b/spec/darwin/commands_spec.rb
@@ -29,7 +29,7 @@ end
 
 describe 'check_routing_table' do
   subject { commands.check_routing_table('192.168.100.0/24') }
-  it { should eq "ip route | grep -E '^192.168.100.0/24 |^default '" }
+  it { should eq "/sbin/ip route | grep -E '^192.168.100.0/24 |^default '" }
 end
 
 describe 'check_resolvable'  do
@@ -69,7 +69,7 @@ end
 
 describe 'check_running' do
   subject { commands.check_running('httpd') }
-  it { should eq 'service httpd status' }
+  it { should eq '/sbin/service httpd status' }
 end
 
 describe 'check_running_under_supervisor' do

--- a/spec/debian/commands_spec.rb
+++ b/spec/debian/commands_spec.rb
@@ -19,7 +19,7 @@ end
 
 describe 'check_routing_table' do
   subject { commands.check_routing_table('192.168.100.0/24') }
-  it { should eq "ip route | grep -E '^192.168.100.0/24 |^default '" }
+  it { should eq "/sbin/ip route | grep -E '^192.168.100.0/24 |^default '" }
 end
 
 describe 'check_reachable'  do
@@ -85,7 +85,7 @@ end
 
 describe 'check_running' do
   subject { commands.check_running('httpd') }
-  it { should eq 'service httpd status' }
+  it { should eq '/sbin/service httpd status' }
 end
 
 
@@ -209,12 +209,12 @@ end
 describe 'check_ipatbles' do
   context 'check a rule without a table and a chain' do
     subject { commands.check_iptables_rule('-P INPUT ACCEPT') }
-    it { should eq "iptables -S | grep -- -P\\ INPUT\\ ACCEPT" }
+    it { should eq "/sbin/iptables -S | grep -- -P\\ INPUT\\ ACCEPT" }
   end
 
   context 'chack a rule with a table and a chain' do
     subject { commands.check_iptables_rule('-P INPUT ACCEPT', 'mangle', 'INPUT') }
-    it { should eq "iptables -t mangle -S INPUT | grep -- -P\\ INPUT\\ ACCEPT" }
+    it { should eq "/sbin/iptables -t mangle -S INPUT | grep -- -P\\ INPUT\\ ACCEPT" }
   end
 end
 

--- a/spec/gentoo/commands_spec.rb
+++ b/spec/gentoo/commands_spec.rb
@@ -19,7 +19,7 @@ end
 
 describe 'check_routing_table' do
   subject { commands.check_routing_table('192.168.100.0/24') }
-  it { should eq "ip route | grep -E '^192.168.100.0/24 |^default '" }
+  it { should eq "/sbin/ip route | grep -E '^192.168.100.0/24 |^default '" }
 end
 
 describe 'check_reachable'  do
@@ -207,12 +207,12 @@ end
 describe 'check_ipatbles' do
   context 'check a rule without a table and a chain' do
     subject { commands.check_iptables_rule('-P INPUT ACCEPT') }
-    it { should eq "iptables -S | grep -- -P\\ INPUT\\ ACCEPT" }
+    it { should eq "/sbin/iptables -S | grep -- -P\\ INPUT\\ ACCEPT" }
   end
 
   context 'chack a rule with a table and a chain' do
     subject { commands.check_iptables_rule('-P INPUT ACCEPT', 'mangle', 'INPUT') }
-    it { should eq "iptables -t mangle -S INPUT | grep -- -P\\ INPUT\\ ACCEPT" }
+    it { should eq "/sbin/iptables -t mangle -S INPUT | grep -- -P\\ INPUT\\ ACCEPT" }
   end
 end
 

--- a/spec/redhat/commands_spec.rb
+++ b/spec/redhat/commands_spec.rb
@@ -4,7 +4,7 @@ include Serverspec::Helper::RedHat
 
 describe 'check_enabled' do
   subject { commands.check_enabled('httpd') }
-  it { should eq 'chkconfig --list httpd | grep 3:on' }
+  it { should eq '/sbin/chkconfig --list httpd | grep 3:on' }
 end
 
 describe 'check_file' do
@@ -19,7 +19,7 @@ end
 
 describe 'check_routing_table' do
   subject { commands.check_routing_table('192.168.100.0/24') }
-  it { should eq "ip route | grep -E '^192.168.100.0/24 |^default '" }
+  it { should eq "/sbin/ip route | grep -E '^192.168.100.0/24 |^default '" }
 end
 
 describe 'check_reachable'  do
@@ -79,7 +79,7 @@ end
 
 describe 'check_running' do
   subject { commands.check_running('httpd') }
-  it { should eq 'service httpd status' }
+  it { should eq '/sbin/service httpd status' }
 end
 
 describe 'check_running_under_supervisor' do
@@ -207,12 +207,12 @@ end
 describe 'check_ipatbles' do
   context 'check a rule without a table and a chain' do
     subject { commands.check_iptables_rule('-P INPUT ACCEPT') }
-    it { should eq "iptables -S | grep -- -P\\ INPUT\\ ACCEPT" }
+    it { should eq "/sbin/iptables -S | grep -- -P\\ INPUT\\ ACCEPT" }
   end
 
   context 'chack a rule with a table and a chain' do
     subject { commands.check_iptables_rule('-P INPUT ACCEPT', 'mangle', 'INPUT') }
-    it { should eq "iptables -t mangle -S INPUT | grep -- -P\\ INPUT\\ ACCEPT" }
+    it { should eq "/sbin/iptables -t mangle -S INPUT | grep -- -P\\ INPUT\\ ACCEPT" }
   end
 end
 
@@ -241,16 +241,16 @@ end
 describe 'check_access_by_user' do
   context 'read access' do
     subject {commands.check_access_by_user '/tmp/something', 'dummyuser1', 'r'}
-    it { should eq  'runuser -s /bin/sh -c "test -r /tmp/something" dummyuser1' }
+    it { should eq  '/sbin/runuser -s /bin/sh -c "test -r /tmp/something" dummyuser1' }
   end
 
   context 'write access' do
     subject {commands.check_access_by_user '/tmp/somethingw', 'dummyuser2', 'w'}
-    it { should eq  'runuser -s /bin/sh -c "test -w /tmp/somethingw" dummyuser2' }
+    it { should eq  '/sbin/runuser -s /bin/sh -c "test -w /tmp/somethingw" dummyuser2' }
   end
 
   context 'execute access' do
     subject {commands.check_access_by_user '/tmp/somethingx', 'dummyuser3', 'x'}
-    it { should eq  'runuser -s /bin/sh -c "test -x /tmp/somethingx" dummyuser3' }
+    it { should eq  '/sbin/runuser -s /bin/sh -c "test -x /tmp/somethingx" dummyuser3' }
   end
 end

--- a/spec/solaris/commands_spec.rb
+++ b/spec/solaris/commands_spec.rb
@@ -19,7 +19,7 @@ end
 
 describe 'check_routing_table' do
   subject { commands.check_routing_table('192.168.100.0/24') }
-  it { should eq "ip route | grep -E '^192.168.100.0/24 |^default '" }
+  it { should eq "/sbin/ip route | grep -E '^192.168.100.0/24 |^default '" }
 end
 
 describe 'check_reachable'  do


### PR DESCRIPTION
Because of lacking explicit path for some commands, e.g. chkconfig, serverspec can not determine those command's locations. Thus, my tests was failed under vagrant and Cent OS 6.3.

Fix this issue by adding absolute path "/sbin" to iptables, ip, chkconfig, service and runuser.
