### PR TITLE
Match gem version when multiple versions installed

### DIFF
--- a/lib/serverspec/backend/exec.rb
+++ b/lib/serverspec/backend/exec.rb
@@ -40,7 +40,7 @@ module Serverspec
         ret = run_command(commands.check_installed_by_gem(package))
         res = ret[:exit_status] == 0
         if res && version
-          res = false if not ret[:stdout].match(/\(#{version}\)/)
+          res = false if not ret[:stdout].match(/#{version}/)
         end
         res
       end


### PR DESCRIPTION
Hey,

If I've got multiple gems installed, the version check fails as it's looking for the version number surrounded by brackets. 

I've got situations where I've legitimately got multiple versions of gems installed, but I still want to check a specific version is installed.

Maybe you want to keep the behaviour of matching only a single version, perhaps there could be something like including_version(version) for the scenario I have?
