### PR TITLE
Fix be_mode and be_executable matcher to be compatible with Mac OS X v10.4.11

### DIFF
--- a/lib/serverspec/commands/darwin.rb
+++ b/lib/serverspec/commands/darwin.rb
@@ -11,7 +11,7 @@ module Serverspec
 
       def check_mode file, mode
         regexp = "^#{mode}$"
-        "ruby -e 'puts (\"%o\" % File.stat(\"#{escape(file)}\").mode)[-3, 3]' | grep -- #{escape(regexp)}"
+        "stat -f%Lp #{escape(file)} | grep -- #{escape(regexp)}"
       end
 
       def check_owner file, owner
@@ -25,7 +25,7 @@ module Serverspec
       end
 
       def get_mode(file)
-        "ruby -e 'puts (\"%o\" % File.stat(\"#{escape(file)}\").mode)[-3, 3]'"
+        "stat -f%Lp #{escape(file)}"
       end
 
       def check_access_by_user file, user, access

--- a/spec/darwin/commands_spec.rb
+++ b/spec/darwin/commands_spec.rb
@@ -43,7 +43,7 @@ end
 
 describe 'check_mode' do
   subject { commands.check_mode('/etc/sudoers', 440) }
-  it { should eq 'ruby -e \'puts ("%o" % File.stat("/etc/sudoers").mode)[-3, 3]\' | grep -- \\^440\\$' }
+  it { should eq 'stat -f%Lp /etc/sudoers | grep -- \\^440\\$' }
 end
 
 describe 'check_owner' do
@@ -58,7 +58,7 @@ end
 
 describe 'get_mode' do
   subject { commands.get_mode('/dev') }
-  it { should eq 'ruby -e \'puts ("%o" % File.stat("/dev").mode)[-3, 3]\'' }
+  it { should eq 'stat -f%Lp /dev' }
 end
 
 describe 'check_access_by_user' do


### PR DESCRIPTION
Update check_mode and get_mode methods for Darwin because "stat -f %A" is not available on Mac OS X v10.4.11. This pull request works for me on Mac OS X v10.4.11.
