### PR TITLE
Fixed SELinux check

### DIFF
--- a/lib/serverspec/commands/linux.rb
+++ b/lib/serverspec/commands/linux.rb
@@ -19,7 +19,7 @@ module Serverspec
       end
 
       def check_selinux mode
-        "getenforce | grep -i -- #{escape(mode)} && grep -i -- ^SELINUX=#{escape(mode)} /etc/selinux/config"
+        "getenforce | grep -i -- #{escape(mode)} && grep -i -- ^SELINUX=#{escape(mode)}$ /etc/selinux/config"
       end
     end
   end

--- a/spec/support/shared_commands_examples.rb
+++ b/spec/support/shared_commands_examples.rb
@@ -215,17 +215,17 @@ end
 shared_examples_for 'support command check_selinux' do
   context 'enforcing' do
     subject { commands.check_selinux('enforcing') }
-    it { should eq "getenforce | grep -i -- enforcing && grep -i -- ^SELINUX=enforcing /etc/selinux/config" }
+    it { should eq "getenforce | grep -i -- enforcing && grep -i -- ^SELINUX=enforcing$ /etc/selinux/config" }
   end
 
   context 'permissive' do
     subject { commands.check_selinux('permissive') }
-    it { should eq "getenforce | grep -i -- permissive && grep -i -- ^SELINUX=permissive /etc/selinux/config" }
+    it { should eq "getenforce | grep -i -- permissive && grep -i -- ^SELINUX=permissive$ /etc/selinux/config" }
   end
 
   context 'disabled' do
     subject { commands.check_selinux('disabled') }
-    it { should eq "getenforce | grep -i -- disabled && grep -i -- ^SELINUX=disabled /etc/selinux/config" }
+    it { should eq "getenforce | grep -i -- disabled && grep -i -- ^SELINUX=disabled$ /etc/selinux/config" }
   end
 end
 


### PR DESCRIPTION
- `grep -i -- SELINUX=#{escape(mode)} /etc/selinux/config` is hit.

`be_disabled`

```
#SELINUX=disabled
SELINUX=enforcing
```

```
SELINUX=disableddddd
```

`grep -i -- ^SELINUX=#{escape(mode)}$ /etc/selinux/config` would better.
