### PR TITLE
Fix a bug of check_installed on Debian squeeze.

### DIFF
--- a/lib/serverspec/commands/debian.rb
+++ b/lib/serverspec/commands/debian.rb
@@ -6,7 +6,8 @@ module Serverspec
       end
 
       def check_installed package
-        "dpkg -s #{escape(package)}"
+        escaped_package = escape(package)
+        "dpkg -s #{escaped_package} && ! dpkg -s #{escaped_package} | grep -E '^Status: .+ not-installed$'"
       end
     end
   end

--- a/spec/debian/commands_spec.rb
+++ b/spec/debian/commands_spec.rb
@@ -61,7 +61,7 @@ end
 
 describe 'check_installed'  do
   subject { commands.check_installed('httpd') }
-  it { should eq 'dpkg -s httpd' }
+  it { should eq "dpkg -s httpd && ! dpkg -s httpd | grep -E '^Status: .+ not-installed$'" }
 end
 
 describe 'check_running' do


### PR DESCRIPTION
On debian squeeze, `dpkg -s <purged package name>` returns 0 as exit code.

For example:

``` bash
vagrant@debian-squeeze:~$ cat /etc/debian_version
6.0.7
vagrant@debian-squeeze:~$ dpkg -s git
Package `git' is not installed and no info is available.
Use dpkg --info (= dpkg-deb --info) to examine archive files,
and dpkg --contents (= dpkg-deb --contents) to list their contents.
vagrant@debian-squeeze:~$ echo $?
1
vagrant@debian-squeeze:~$ sudo apt-get install git
# abbr.
vagrant@debian-squeeze:~$ dpkg -s git
# abbr.
vagrant@debian-squeeze:~$ echo $?
0
vagrant@debian-squeeze:~$ sudo apt-get purge git
# abbr.
vagrant@debian-squeeze:~$ dpkg -s git
Package: git
Status: unknown ok not-installed
Priority: optional
Section: vcs
vagrant@debian-squeeze:~$ echo $?
0
```

Because of this problem, I use `dpkg -s <package> && ! dpkg -s <package> | grep -E '^Status: .+ not-installed$'` instead of `dpkg -s <package>`

I tested this command on Ubuntu (Precise) and Debian (Squeeze).
Test log is here: https://gist.github.com/ryotarai/5729755
