### PR TITLE
use 'env' to set PATH

### DIFF
--- a/lib/serverspec/backend/exec.rb
+++ b/lib/serverspec/backend/exec.rb
@@ -36,7 +36,7 @@ module Serverspec
       def build_command(cmd)
         path = Serverspec.configuration.path || RSpec.configuration.path
         if path
-          cmd = "PATH=#{path}:$PATH #{cmd}"
+          cmd = "env PATH=#{path}:$PATH #{cmd}"
         end
         cmd
       end
@@ -45,7 +45,7 @@ module Serverspec
         path = Serverspec.configuration.path || RSpec.configuration.path
         if Serverspec.configuration.pre_command
           cmd = "#{Serverspec.configuration.pre_command} && #{cmd}"
-          cmd = "PATH=#{path}:$PATH #{cmd}" if path
+          cmd = "env PATH=#{path}:$PATH #{cmd}" if path
         end
         cmd
       end


### PR DESCRIPTION
# Problem

In my CentOS 5.9 sudo 1.7.2 environment, I got following rake spec result.

```
  1) Service "httpd" 
     Failure/Error: it { should be_enabled   }
       sudo PATH=/sbin:/usr/sbin:$PATH chkconfig --list httpd | grep 3:on
       sudo: chkconfig: command not found
```
# Cause

sudo PATH=... is no effect following command.

```
$ echo $PATH
/usr/kerberos/bin:/usr/local/bin:/bin:/usr/bin
$ sudo PATH=/sbin chkconfig
sudo: chkconfig: command not found
$ sudo env PATH=/sbin chkconfig
chkconfig バージョン 1.3.30.2 - Copyright (C) 1997-2000 Red Hat, Inc.
このソフトウェアは GNU 一般公共使用許諾契約書に従って無償で再配布することができます。

使用法:  chkconfig --list [名前]
         chkconfig --add <名前>
         chkconfig --del <名前>
         chkconfig [--level <レベル>] <名前> <on|off|reset|resetpriorities>
```
# Patch

add 'env' to command if set RSpec.configuration.path or pre_command
