### PR TITLE
Update serverspec.gemspec

### DIFF
--- a/serverspec.gemspec
+++ b/serverspec.gemspec
@@ -8,8 +8,8 @@ Gem::Specification.new do |spec|
   spec.version       = Serverspec::VERSION
   spec.authors       = ["Gosuke Miyashita"]
   spec.email         = ["gosukenator@gmail.com"]
-  spec.description   = %q{RSpec tests for your servers provisioned by Puppet, Chef or anything else}
-  spec.summary       = %q{RSpec tests for your servers provisioned by Puppet, Chef or anything else}
+  spec.description   = %q{RSpec tests for your servers configured by Puppet, Chef or anything else}
+  spec.summary       = %q{RSpec tests for your servers configured by Puppet, Chef or anything else}
   spec.homepage      = "http://serverspec.org/"
   spec.license       = "MIT"
 
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "net-ssh"
-  spec.add_runtime_dependency "rspec", "~> 2.0"
+  spec.add_runtime_dependency "rspec", "~> 2.13.0"
   spec.add_runtime_dependency "highline"
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
I have updated serverspec.gemspec because serverspec 0.6.0 or later uses exception_class_name_for method that requires RSpec 2.13.0 or later.

Also I have updated spec.description and spec.summary in serverspec.gemspec according to README.md.
