### PR TITLE
add check_installed.with_version for Solaris

### DIFF
--- a/lib/serverspec/commands/solaris.rb
+++ b/lib/serverspec/commands/solaris.rb
@@ -6,7 +6,11 @@ module Serverspec
       end
 
       def check_installed(package, version=nil)
-        "pkg list -H #{escape(package)} 2> /dev/null"
+        cmd = "pkg list -H #{escape(package)} 2> /dev/null"
+        if ! version.nil?
+          cmd = "#{cmd} | grep -qw -- #{escape(version)}"
+        end
+        cmd
       end
 
       def check_listening(port)

--- a/spec/solaris/commands_spec.rb
+++ b/spec/solaris/commands_spec.rb
@@ -57,6 +57,11 @@ describe 'check_installed' do
   it { should eq 'pkg list -H httpd 2> /dev/null' }
 end
 
+describe 'check_installed' do
+  subject { commands.check_installed('httpd', '2.2') }
+  it { should eq 'pkg list -H httpd 2> /dev/null | grep -qw -- 2.2' }
+end
+
 describe 'check_file_contain_within' do
   context 'contain a pattern in the file' do
     subject { commands.check_file_contain_within('Gemfile', 'rspec') }

--- a/spec/solaris/package_spec.rb
+++ b/spec/solaris/package_spec.rb
@@ -4,6 +4,7 @@ include Serverspec::Helper::Solaris
 
 describe 'Serverspec package matchers of Solaris family' do
   it_behaves_like 'support package installed matcher', 'httpd'
+  it_behaves_like 'support package installed with version matcher', 'httpd', '2.2'
   it_behaves_like 'support package installed by gem matcher', 'jekyll'
   it_behaves_like 'support package installed by gem with version matcher', 'jekyll', '1.1.1'
   it_behaves_like 'support package installed by npm matcher', 'bower'


### PR DESCRIPTION
I've added check_installed.with_version for Solaris, like #164.
