### PR TITLE
Remove `-s sh` of check_access command

### DIFF
--- a/lib/serverspec/commands/linux.rb
+++ b/lib/serverspec/commands/linux.rb
@@ -4,7 +4,7 @@ module Serverspec
   module Commands
     class Linux < Base
       def check_access_by_user(file, user, access)
-        "su -s sh -c \"test -#{access} #{file}\" #{user}"
+        "su -c \"test -#{access} #{file}\" #{user}"
       end
 
       def check_iptables_rule(rule, table=nil, chain=nil)

--- a/lib/serverspec/commands/redhat.rb
+++ b/lib/serverspec/commands/redhat.rb
@@ -3,7 +3,7 @@ module Serverspec
     class RedHat < Linux
       def check_access_by_user(file, user, access)
         # Redhat-specific
-        "runuser -s sh -c \"test -#{access} #{file}\" #{user}"
+        "runuser -c \"test -#{access} #{file}\" #{user}"
       end
 
       def check_enabled(service)

--- a/spec/redhat/commands_spec.rb
+++ b/spec/redhat/commands_spec.rb
@@ -94,16 +94,16 @@ end
 describe 'check_access_by_user' do
   context 'read access' do
     subject {commands.check_access_by_user '/tmp/something', 'dummyuser1', 'r'}
-    it { should eq  'runuser -s sh -c "test -r /tmp/something" dummyuser1' }
+    it { should eq  'runuser -c "test -r /tmp/something" dummyuser1' }
   end
 
   context 'write access' do
     subject {commands.check_access_by_user '/tmp/somethingw', 'dummyuser2', 'w'}
-    it { should eq  'runuser -s sh -c "test -w /tmp/somethingw" dummyuser2' }
+    it { should eq  'runuser -c "test -w /tmp/somethingw" dummyuser2' }
   end
 
   context 'execute access' do
     subject {commands.check_access_by_user '/tmp/somethingx', 'dummyuser3', 'x'}
-    it { should eq  'runuser -s sh -c "test -x /tmp/somethingx" dummyuser3' }
+    it { should eq  'runuser -c "test -x /tmp/somethingx" dummyuser3' }
   end
 end

--- a/spec/support/shared_commands_examples.rb
+++ b/spec/support/shared_commands_examples.rb
@@ -252,17 +252,17 @@ end
 shared_examples_for 'support command check_access_by_user' do
   context 'read access' do
     subject {commands.check_access_by_user '/tmp/something', 'dummyuser1', 'r'}
-    it { should eq  'su -s sh -c "test -r /tmp/something" dummyuser1' }
+    it { should eq  'su -c "test -r /tmp/something" dummyuser1' }
   end
 
   context 'write access' do
     subject {commands.check_access_by_user '/tmp/somethingw', 'dummyuser2', 'w'}
-    it { should eq  'su -s sh -c "test -w /tmp/somethingw" dummyuser2' }
+    it { should eq  'su -c "test -w /tmp/somethingw" dummyuser2' }
   end
 
   context 'execute access' do
     subject {commands.check_access_by_user '/tmp/somethingx', 'dummyuser3', 'x'}
-    it { should eq  'su -s sh -c "test -x /tmp/somethingx" dummyuser3' }
+    it { should eq  'su -c "test -x /tmp/somethingx" dummyuser3' }
   end
 end
 


### PR DESCRIPTION
It's not allowed to execute because it's not full path and it's not needed.
