### PR TITLE
fix SmartOS detection

### DIFF
--- a/lib/serverspec/backend/exec.rb
+++ b/lib/serverspec/backend/exec.rb
@@ -200,7 +200,7 @@ module Serverspec
         elsif (os = run_command('uname -sr')[:stdout]) && os =~ /SunOS/i
           if os =~ /5.10/
             'Solaris10'
-          elsif run_command('grep -q SmartOS /etc/release')
+          elsif run_command('grep -q SmartOS /etc/release')[:exit_status] == 0
             'SmartOS'
           else
             'Solaris'


### PR DESCRIPTION
I've fixed SmartOS detection.

"run_command('grep -q SmartOS /etc/release') " returns array
and Solaris 11 is detected as SmartOS.

To avoid this problem, I've added exit status check.
