### PR TITLE
Fix custom failure message duplication

### DIFF
--- a/lib/serverspec.rb
+++ b/lib/serverspec.rb
@@ -50,22 +50,6 @@ RSpec.configure do |c|
 end
 
 module RSpec
-  module Matchers
-    module DSL
-      class Matcher
-        def failure_message_for_should(&block)
-          message =  "#{example.metadata[:command]}\n"
-          message += "#{example.metadata[:stdout]}"
-          message
-        end
-        def failure_message_for_should_not(&block)
-          message =  "#{example.metadata[:command]}\n"
-          message += "#{example.metadata[:stdout]}"
-          message
-        end
-      end
-    end
-  end
   module Core
     module Formatters
       class BaseTextFormatter < BaseFormatter


### PR DESCRIPTION
Failure message duplcates if the matcher is defined in serverspec/matchers/*.

So I've removed overriding failure_message_for_should and failure_message_for_should_not.
