### PR TITLE
fix check_listening for solaris.

### DIFF
--- a/lib/serverspec/commands/solaris.rb
+++ b/lib/serverspec/commands/solaris.rb
@@ -14,8 +14,8 @@ module Serverspec
       end
 
       def check_listening(port)
-        regexp = "\.#{port} "
-        "netstat -an 2> /dev/null | egrep 'LISTEN|Idle' | grep -- #{escape(regexp)}"
+        regexp = "\\.#{port} "
+        "netstat -an 2> /dev/null | grep -- LISTEN | grep -- #{escape(regexp)}"
       end
 
       def check_listening_with_protocol(port, protocol)

--- a/spec/solaris/port_spec.rb
+++ b/spec/solaris/port_spec.rb
@@ -4,7 +4,7 @@ include Serverspec::Helper::Solaris
 
 describe port(80) do
   it { should be_listening }
-  its(:command) { should eq %q!netstat -an 2> /dev/null | egrep 'LISTEN|Idle' | grep -- .80\\ ! }
+  its(:command) { should eq %q!netstat -an 2> /dev/null | grep -- LISTEN | grep -- \\\\.80\\ ! }
 end
 
 describe port('invalid') do

--- a/spec/solaris11/port_spec.rb
+++ b/spec/solaris11/port_spec.rb
@@ -4,7 +4,7 @@ include Serverspec::Helper::Solaris11
 
 describe port(80) do
   it { should be_listening }
-  its(:command) { should eq %q!netstat -an 2> /dev/null | egrep 'LISTEN|Idle' | grep -- .80\\ ! }
+  its(:command) { should eq %q!netstat -an 2> /dev/null | grep -- LISTEN | grep -- \\\\.80\\ ! }
 end
 
 describe port('invalid') do


### PR DESCRIPTION
fix #209 with adding '\' to escape
and remove 'Idle' which is not needed.

I forgot why I added 'Idle'.
