### PR TITLE
fix check_listening_with_protocol for solaris.

### DIFF
--- a/lib/serverspec/commands/solaris.rb
+++ b/lib/serverspec/commands/solaris.rb
@@ -19,8 +19,8 @@ module Serverspec
       end
 
       def check_listening_with_protocol(port, protocol)
-        regexp = ".*\.#{port} "
-        "netstat -an -P #{escape(protocol)} 2> /dev/null | egrep 'LISTEN|Idle' | grep -- #{escape(regexp)}"
+        regexp = ".*\\.#{port} "
+        "netstat -an -P #{escape(protocol)} 2> /dev/null | grep -- LISTEN | grep -- #{escape(regexp)}"
       end
 
       def check_running(service)

--- a/spec/solaris/port_spec.rb
+++ b/spec/solaris/port_spec.rb
@@ -13,12 +13,12 @@ end
 
 describe port(80) do
   it { should be_listening.with("tcp") }
-  its(:command) { should eq %q!netstat -an -P tcp 2> /dev/null | egrep 'LISTEN|Idle' | grep -- .\\*.80\\ ! }
+  its(:command) { should eq %q!netstat -an -P tcp 2> /dev/null | grep -- LISTEN | grep -- .\\*\\\\.80\\ ! }
 end
 
 describe port(123) do
   it { should be_listening.with("udp") }
-  its(:command) { should eq %q!netstat -an -P udp 2> /dev/null | egrep 'LISTEN|Idle' | grep -- .\\*.123\\ ! }
+  its(:command) { should eq %q!netstat -an -P udp 2> /dev/null | grep -- LISTEN | grep -- .\\*\\\\.123\\ ! }
 end
 
 describe port(80) do


### PR DESCRIPTION
fix #209 with adding '\' to escape
and removing 'Idle' which is not needed.

I forgot why I added 'Idle'.
