### PR TITLE
Support for a debian box not installed selinux-basics

### DIFF
--- a/lib/serverspec/commands/linux.rb
+++ b/lib/serverspec/commands/linux.rb
@@ -17,7 +17,11 @@ module Serverspec
       end
 
       def check_selinux(mode)
-        "getenforce | grep -i -- #{escape(mode)} && grep -i -- ^SELINUX=#{escape(mode)}$ /etc/selinux/config"
+        cmd =  "sh -c \""
+        cmd += "[ ! -f /etc/selinux/config ] || " if mode == "disabled"
+        cmd += "(getenforce | grep -i -- #{escape(mode)} "
+        cmd += "&& grep -i -- ^SELINUX=#{escape(mode)}$ /etc/selinux/config)\""
+        cmd
       end
 
       def check_kernel_module_loaded(name)

--- a/spec/debian/selinux_spec.rb
+++ b/spec/debian/selinux_spec.rb
@@ -4,15 +4,15 @@ include Serverspec::Helper::Debian
 
 describe selinux do
   it { should be_enforcing }
-  its(:command) { should eq "getenforce | grep -i -- enforcing && grep -i -- ^SELINUX=enforcing$ /etc/selinux/config" }
+  its(:command) { should eq %q{sh -c "(getenforce | grep -i -- enforcing && grep -i -- ^SELINUX=enforcing$ /etc/selinux/config)"}}
 end
 
 describe selinux do
   it { should be_permissive }
-  its(:command) { should eq "getenforce | grep -i -- permissive && grep -i -- ^SELINUX=permissive$ /etc/selinux/config" }
+  its(:command) { should eq %q{sh -c "(getenforce | grep -i -- permissive && grep -i -- ^SELINUX=permissive$ /etc/selinux/config)"} }
 end
 
 describe selinux do
   it { should be_disabled }
-  its(:command) { should eq "getenforce | grep -i -- disabled && grep -i -- ^SELINUX=disabled$ /etc/selinux/config" }
+  its(:command) { should eq %q{sh -c "[ ! -f /etc/selinux/config ] || (getenforce | grep -i -- disabled && grep -i -- ^SELINUX=disabled$ /etc/selinux/config)"} }
 end

--- a/spec/gentoo/selinux_spec.rb
+++ b/spec/gentoo/selinux_spec.rb
@@ -4,15 +4,15 @@ include Serverspec::Helper::Gentoo
 
 describe selinux do
   it { should be_enforcing }
-  its(:command) { should eq "getenforce | grep -i -- enforcing && grep -i -- ^SELINUX=enforcing$ /etc/selinux/config" }
+  its(:command) { should eq %q{sh -c "(getenforce | grep -i -- enforcing && grep -i -- ^SELINUX=enforcing$ /etc/selinux/config)"}}
 end
 
 describe selinux do
   it { should be_permissive }
-  its(:command) { should eq "getenforce | grep -i -- permissive && grep -i -- ^SELINUX=permissive$ /etc/selinux/config" }
+  its(:command) { should eq %q{sh -c "(getenforce | grep -i -- permissive && grep -i -- ^SELINUX=permissive$ /etc/selinux/config)"} }
 end
 
 describe selinux do
   it { should be_disabled }
-  its(:command) { should eq "getenforce | grep -i -- disabled && grep -i -- ^SELINUX=disabled$ /etc/selinux/config" }
+  its(:command) { should eq %q{sh -c "[ ! -f /etc/selinux/config ] || (getenforce | grep -i -- disabled && grep -i -- ^SELINUX=disabled$ /etc/selinux/config)"} }
 end

--- a/spec/redhat/selinux_spec.rb
+++ b/spec/redhat/selinux_spec.rb
@@ -4,15 +4,15 @@ include Serverspec::Helper::RedHat
 
 describe selinux do
   it { should be_enforcing }
-  its(:command) { should eq "getenforce | grep -i -- enforcing && grep -i -- ^SELINUX=enforcing$ /etc/selinux/config" }
+  its(:command) { should eq %q{sh -c "(getenforce | grep -i -- enforcing && grep -i -- ^SELINUX=enforcing$ /etc/selinux/config)"}}
 end
 
 describe selinux do
   it { should be_permissive }
-  its(:command) { should eq "getenforce | grep -i -- permissive && grep -i -- ^SELINUX=permissive$ /etc/selinux/config" }
+  its(:command) { should eq %q{sh -c "(getenforce | grep -i -- permissive && grep -i -- ^SELINUX=permissive$ /etc/selinux/config)"} }
 end
 
 describe selinux do
   it { should be_disabled }
-  its(:command) { should eq "getenforce | grep -i -- disabled && grep -i -- ^SELINUX=disabled$ /etc/selinux/config" }
+  its(:command) { should eq %q{sh -c "[ ! -f /etc/selinux/config ] || (getenforce | grep -i -- disabled && grep -i -- ^SELINUX=disabled$ /etc/selinux/config)"} }
 end


### PR DESCRIPTION
On a debian box not installed `selinux-basics`, serverspec does not work right with:

```
describe selinux do
  it { should be_disabled }
end
```

because `getenforce` and `/etc/selinux/config` does not exists.
