### PR TITLE
Omit brackets when be_permissive and be_enforcing of selinux resource type

### DIFF
--- a/lib/serverspec/commands/linux.rb
+++ b/lib/serverspec/commands/linux.rb
@@ -18,9 +18,10 @@ module Serverspec
 
       def check_selinux(mode)
         cmd =  ""
-        cmd += "test ! -f /etc/selinux/config || " if mode == "disabled"
-        cmd += "(getenforce | grep -i -- #{escape(mode)} "
-        cmd += "&& grep -i -- ^SELINUX=#{escape(mode)}$ /etc/selinux/config)"
+        cmd += "test ! -f /etc/selinux/config || (" if mode == "disabled"
+        cmd += "getenforce | grep -i -- #{escape(mode)} "
+        cmd += "&& grep -i -- ^SELINUX=#{escape(mode)}$ /etc/selinux/config"
+        cmd += ")" if mode == "disabled"
         cmd
       end
 

--- a/spec/debian/selinux_spec.rb
+++ b/spec/debian/selinux_spec.rb
@@ -4,12 +4,12 @@ include Serverspec::Helper::Debian
 
 describe selinux do
   it { should be_enforcing }
-  its(:command) { should eq "(getenforce | grep -i -- enforcing && grep -i -- ^SELINUX=enforcing$ /etc/selinux/config)" }
+  its(:command) { should eq "getenforce | grep -i -- enforcing && grep -i -- ^SELINUX=enforcing$ /etc/selinux/config" }
 end
 
 describe selinux do
   it { should be_permissive }
-  its(:command) { should eq "(getenforce | grep -i -- permissive && grep -i -- ^SELINUX=permissive$ /etc/selinux/config)" }
+  its(:command) { should eq "getenforce | grep -i -- permissive && grep -i -- ^SELINUX=permissive$ /etc/selinux/config" }
 end
 
 describe selinux do

--- a/spec/gentoo/selinux_spec.rb
+++ b/spec/gentoo/selinux_spec.rb
@@ -4,12 +4,12 @@ include Serverspec::Helper::Gentoo
 
 describe selinux do
   it { should be_enforcing }
-  its(:command) { should eq "(getenforce | grep -i -- enforcing && grep -i -- ^SELINUX=enforcing$ /etc/selinux/config)" }
+  its(:command) { should eq "getenforce | grep -i -- enforcing && grep -i -- ^SELINUX=enforcing$ /etc/selinux/config" }
 end
 
 describe selinux do
   it { should be_permissive }
-  its(:command) { should eq "(getenforce | grep -i -- permissive && grep -i -- ^SELINUX=permissive$ /etc/selinux/config)" }
+  its(:command) { should eq "getenforce | grep -i -- permissive && grep -i -- ^SELINUX=permissive$ /etc/selinux/config" }
 end
 
 describe selinux do

--- a/spec/redhat/selinux_spec.rb
+++ b/spec/redhat/selinux_spec.rb
@@ -4,12 +4,12 @@ include Serverspec::Helper::RedHat
 
 describe selinux do
   it { should be_enforcing }
-  its(:command) { should eq "(getenforce | grep -i -- enforcing && grep -i -- ^SELINUX=enforcing$ /etc/selinux/config)" }
+  its(:command) { should eq "getenforce | grep -i -- enforcing && grep -i -- ^SELINUX=enforcing$ /etc/selinux/config" }
 end
 
 describe selinux do
   it { should be_permissive }
-  its(:command) { should eq "(getenforce | grep -i -- permissive && grep -i -- ^SELINUX=permissive$ /etc/selinux/config)" }
+  its(:command) { should eq "getenforce | grep -i -- permissive && grep -i -- ^SELINUX=permissive$ /etc/selinux/config" }
 end
 
 describe selinux do


### PR DESCRIPTION
Because they cause a error when used with sudo.(Ref: #217)
