### PR TITLE
Change regular expression for adding sudo with exclamation.

### DIFF
--- a/lib/serverspec/backend/ssh.rb
+++ b/lib/serverspec/backend/ssh.rb
@@ -20,8 +20,8 @@ module Serverspec
         cmd = super(cmd)
         if RSpec.configuration.ssh.options[:user] != 'root'
           cmd = "sudo #{cmd}"
-          cmd.gsub!(/(\&\&\s*\(?)/, "\\1sudo ")
-          cmd.gsub!(/(\|\|\s*\(?)/, "\\1sudo ")
+          cmd.gsub!(/(\&\&\s*!*\s*\(?)/, "\\1sudo ")
+          cmd.gsub!(/(\|\|\s*!*\s*\(?)/, "\\1sudo ")
         end
         cmd
       end


### PR DESCRIPTION
sudoを追加する際に否定演算子を考慮するように正規表現を変更しました。
否定演算子はDebian系のbe_installedで使用されているのを確認しています。
