### PR TITLE
Find Vagrantfile with ascending directory.

### DIFF
--- a/lib/serverspec/setup.rb
+++ b/lib/serverspec/setup.rb
@@ -198,8 +198,16 @@ EOF
       end
     end
 
+    def self.find_vagrantfile
+      Pathname.new(Dir.pwd).ascend do |dir|
+        path = File.expand_path("Vagrantfile", dir)
+        return path if File.exists?(path)
+      end
+      nil
+    end
+
     def self.auto_vagrant_configuration
-      if File.exists?("Vagrantfile")
+      if find_vagrantfile
         vagrant_list = `vagrant status`
         list_of_vms = []
         if vagrant_list != ''


### PR DESCRIPTION
## Vagrantfile lookup path

> Vagrant climbs up the directory tree looking for the first Vagrantfile it can find, starting first in the current directory.

http://docs.vagrantup.com/v2/vagrantfile/index.html
## Improvement

`serverspec-init` climbs up the directory tree looking for the first `Vagrantfile` it can find, starting first in the current directory.
## Log

```
➜  grandchild  pwd
/tmp/serverspec/child/grandchild
➜  grandchild  ls /tmp{,/serverspec,/serverspec/child,/serverspec/child/grandchild}/Vagrantfile
ls: /tmp/Vagrantfile: No such file or directory
ls: /tmp/serverspec/Vagrantfile: No such file or directory
ls: /tmp/serverspec/child/Vagrantfile: No such file or directory
ls: /tmp/serverspec/child/grandchild/Vagrantfile: No such file or directory
➜  grandchild  ./bin/serverspec-init
Select a backend type:

  1) SSH
  2) Exec (local)

Select number: 1

Vagrant instance y/n: y
Auto-configure Vagrant from Vagrantfile? y/n: y
Vagrantfile not found in directory!
➜  grandchild  cd ../..
➜  serverspec  vagrant init precise64
A `Vagrantfile` has been placed in this directory. You are now
ready to `vagrant up` your first virtual environment! Please read
the comments in the Vagrantfile as well as documentation on
`vagrantup.com` for more information on using Vagrant.
➜  serverspec  cd child/grandchild
➜  grandchild  ./bin/serverspec-init
Select a backend type:

  1) SSH
  2) Exec (local)

Select number: 1

Vagrant instance y/n: y
Auto-configure Vagrant from Vagrantfile? y/n: y
 + spec/
 + spec/default/
 + spec/default/httpd_spec.rb
 + spec/spec_helper.rb
 + Rakefile
```
