### PR TITLE
sudo: source: command not found

### DIFF
--- a/lib/serverspec/backend/ssh.rb
+++ b/lib/serverspec/backend/ssh.rb
@@ -26,16 +26,6 @@ module Serverspec
         cmd
       end
 
-      def add_pre_command(cmd)
-        cmd = super(cmd)
-        user = RSpec.configuration.ssh.options[:user]
-        pre_command = Serverspec.configuration.pre_command
-        if pre_command && user != 'root'
-          cmd = "sudo #{cmd}"
-        end
-        cmd
-      end
-
       private
       def ssh_exec!(command)
         stdout_data = ''

--- a/spec/backend/ssh/configuration_spec.rb
+++ b/spec/backend/ssh/configuration_spec.rb
@@ -61,7 +61,7 @@ describe 'pre_command is set and user is non-root' do
   let(:pre_command) { 'source ~/.zshrc' }
   context file('/etc/passwd') do
     it { should be_file }
-    its(:command) { should eq 'sudo source ~/.zshrc && sudo test -f /etc/passwd' }
+    its(:command) { should eq 'source ~/.zshrc && sudo test -f /etc/passwd' }
   end
 end
 
@@ -92,7 +92,7 @@ describe 'path pre_command and set and user is non-root' do
   let(:pre_command) { 'source ~/.zshrc' }
   context file('/etc/passwd') do
     it { should be_file }
-    its(:command) { should eq 'sudo env PATH=/sbin:/usr/sbin:$PATH source ~/.zshrc && sudo env PATH=/sbin:/usr/sbin:$PATH test -f /etc/passwd' }
+    its(:command) { should eq 'env PATH=/sbin:/usr/sbin:$PATH source ~/.zshrc && sudo env PATH=/sbin:/usr/sbin:$PATH test -f /etc/passwd' }
   end
 end
 


### PR DESCRIPTION
http://serverspec.org/advanced_tips.html にあるような `let(:pre_command) { 'source ~/.zshrc' }` だと shell commandなので sudoが自動的に付加されるとエラーになります。なので、sudoを付加するメソッドを取り除きました。
