### PR TITLE
Fix a bug in contain matcher with regexp.

### DIFF
--- a/lib/serverspec/commands/base.rb
+++ b/lib/serverspec/commands/base.rb
@@ -6,7 +6,14 @@ module Serverspec
       class NotImplementedError < Exception; end
 
       def escape(target)
-        Shellwords.shellescape(target.to_s())
+        str = case target
+              when Regexp
+                target.source
+              else
+                target.to_s
+              end
+
+        Shellwords.shellescape(str)
       end
 
       def check_enabled(service, level=3)

--- a/spec/darwin/file_spec.rb
+++ b/spec/darwin/file_spec.rb
@@ -35,6 +35,11 @@ describe file('/etc/ssh/sshd_config') do
 end
 
 describe file('/etc/ssh/sshd_config') do
+  it { should contain /^This is the sshd server system-wide configuration file/ }
+  its(:command) { should eq "grep -q -- \\^This\\ is\\ the\\ sshd\\ server\\ system-wide\\ configuration\\ file /etc/ssh/sshd_config" }
+end
+
+describe file('/etc/ssh/sshd_config') do
   it { should_not contain 'This is invalid text!!' }
 end
 

--- a/spec/debian/file_spec.rb
+++ b/spec/debian/file_spec.rb
@@ -35,6 +35,11 @@ describe file('/etc/ssh/sshd_config') do
 end
 
 describe file('/etc/ssh/sshd_config') do
+  it { should contain /^This is the sshd server system-wide configuration file/ }
+  its(:command) { should eq "grep -q -- \\^This\\ is\\ the\\ sshd\\ server\\ system-wide\\ configuration\\ file /etc/ssh/sshd_config" }
+end
+
+describe file('/etc/ssh/sshd_config') do
   it { should_not contain 'This is invalid text!!' }
 end
 

--- a/spec/gentoo/file_spec.rb
+++ b/spec/gentoo/file_spec.rb
@@ -35,6 +35,11 @@ describe file('/etc/ssh/sshd_config') do
 end
 
 describe file('/etc/ssh/sshd_config') do
+  it { should contain /^This is the sshd server system-wide configuration file/ }
+  its(:command) { should eq "grep -q -- \\^This\\ is\\ the\\ sshd\\ server\\ system-wide\\ configuration\\ file /etc/ssh/sshd_config" }
+end
+
+describe file('/etc/ssh/sshd_config') do
   it { should_not contain 'This is invalid text!!' }
 end
 

--- a/spec/redhat/file_spec.rb
+++ b/spec/redhat/file_spec.rb
@@ -35,6 +35,11 @@ describe file('/etc/ssh/sshd_config') do
 end
 
 describe file('/etc/ssh/sshd_config') do
+  it { should contain /^This is the sshd server system-wide configuration file/ }
+  its(:command) { should eq "grep -q -- \\^This\\ is\\ the\\ sshd\\ server\\ system-wide\\ configuration\\ file /etc/ssh/sshd_config" }
+end
+
+describe file('/etc/ssh/sshd_config') do
   it { should_not contain 'This is invalid text!!' }
 end
 

--- a/spec/solaris/file_spec.rb
+++ b/spec/solaris/file_spec.rb
@@ -35,6 +35,11 @@ describe file('/etc/ssh/sshd_config') do
 end
 
 describe file('/etc/ssh/sshd_config') do
+  it { should contain /^This is the sshd server system-wide configuration file/ }
+  its(:command) { should eq "grep -q -- \\^This\\ is\\ the\\ sshd\\ server\\ system-wide\\ configuration\\ file /etc/ssh/sshd_config" }
+end
+
+describe file('/etc/ssh/sshd_config') do
   it { should_not contain 'This is invalid text!!' }
 end
 

--- a/spec/solaris11/file_spec.rb
+++ b/spec/solaris11/file_spec.rb
@@ -35,6 +35,11 @@ describe file('/etc/ssh/sshd_config') do
 end
 
 describe file('/etc/ssh/sshd_config') do
+  it { should contain /^This is the sshd server system-wide configuration file/ }
+  its(:command) { should eq "grep -q -- \\^This\\ is\\ the\\ sshd\\ server\\ system-wide\\ configuration\\ file /etc/ssh/sshd_config" }
+end
+
+describe file('/etc/ssh/sshd_config') do
   it { should_not contain 'This is invalid text!!' }
 end
 


### PR DESCRIPTION
`Regexp#to_s` behaves like the following:

```
[1] pry(main)> /^hello$/.to_s
=> "(?-mix:^hello$)"
```

`-mix` means disabling `m`, `i` and `x` options.
To use these options, we should use `grep -P` (perl regexp) instead of `grep`.
But `grep -P` is highly experimental and `grep -P` may warn of unimplemented features.

So I use `Regexp#source` instead of `Regexp#to_s`.
`Regexp#source` behaves like the following:

```
[2] pry(main)> /^hello$/.source
=> "^hello$"
```
