### PR TITLE
fix check_file_contain to do exact match

### DIFF
--- a/lib/serverspec/commands/base.rb
+++ b/lib/serverspec/commands/base.rb
@@ -114,7 +114,7 @@ module Serverspec
       end
 
       def check_file_contain(file, expected_pattern)
-        "#{check_file_contain_with_regexp(file, expected_pattern)} || #{check_file_contain_with_fixed_strings(file, expected_pattern)}"
+        "#{check_file_contain_with_fixed_strings(file, expected_pattern)}"
       end
 
       def check_file_contain_with_regexp(file, expected_pattern)


### PR DESCRIPTION
spec/localhost/test_spec.rb:

``` ruby
require 'spec_helper'

describe file( '/tmp/smb.conf' ) do
  it { should contain '[global]' }
  it { should contain '[g]' }
  it { should contain '[globalconfig]' }
end
```

/tmp/smb.conf:

```
[global]
```

Serverspec result:

```
% rspec spec/localhost/test_spec.rb
...

Finished in 0.01395 seconds
3 examples, 0 failures
%
```

Expected result: only 1 succeeded.

```
% grep -- \[global\] /tmp/smb.conf
[global]
% grep -F -- \[global\] /tmp/smb.conf
[global]
%
```

```
% grep -- \[g\] /tmp/smb.conf
[global]
% grep -F -- \[g\] /tmp/smb.conf
%
```

```
% grep -- \[globalconfig\] /tmp/smb.conf
[global]
% grep -F -- \[globalconfig\] /tmp/smb.conf
%
```

i think better that check_file_contain do exact match (check_file_contain_with_fixed_strings) only.
still doing exact match resolves #232.

spec/localhost/test_spec2.rb:

``` ruby
require 'spec_helper'

describe file( '/tmp/exports' ) do
  it { should contain '/export *(rw,no_root_squash)' }
end

describe file( '/tmp/rsyslog.conf' ) do
  it { should contain "$IncludeConfig /etc/rsyslog.d/*.conf" }
end
```

/tmp/exports:

```
/export *(rw,no_root_squash)
```

/tmp/rsyslog.conf:

```
$IncludeConfig /etc/rsyslog.d/*.conf
```

Serverspec (with this pull-req) result:

```
% rspec spec/localhost/test_spec2.rb
..

Finished in 0.01192 seconds
2 examples, 0 failures
%
```
