### PR TITLE
Fix be_linked_to for Darwin

### DIFF
--- a/lib/serverspec/commands/darwin.rb
+++ b/lib/serverspec/commands/darwin.rb
@@ -11,6 +11,10 @@ module Serverspec
         "openssl sha256 #{escape(file)} | cut -d'=' -f2 | cut -c 2- | grep -E ^#{escape(expected)}$"
       end
 
+      def check_link(link, target)
+        "stat -f %Y #{escape(link)} | grep -- #{escape(target)}"
+      end
+
       def check_mode(file, mode)
         regexp = "^#{mode}$"
         "stat -f%Lp #{escape(file)} | grep -- #{escape(regexp)}"

--- a/spec/darwin/file_spec.rb
+++ b/spec/darwin/file_spec.rb
@@ -99,7 +99,7 @@ end
 
 describe file('/etc/pam.d/system-auth') do
   it { should be_linked_to '/etc/pam.d/system-auth-ac' }
-  its(:command) { should eq "stat -c %N /etc/pam.d/system-auth | grep -- /etc/pam.d/system-auth-ac" }
+  its(:command) { should eq "stat -f %Y /etc/pam.d/system-auth | grep -- /etc/pam.d/system-auth-ac" }
 end
 
 describe file('dummy-link') do


### PR DESCRIPTION
I've fixed `be_linked_to` matcher to support Darwin based OS.
