### PR TITLE
suport pear in check_installed

### DIFF
--- a/lib/serverspec/commands/base.rb
+++ b/lib/serverspec/commands/base.rb
@@ -192,6 +192,13 @@ module Serverspec
         cmd
       end
 
+      def check_installed_by_pear(name, version=nil)
+        regexp = "^#{name}"
+        cmd = "pear list | grep -w -- #{escape(regexp)}"
+        cmd = "#{cmd} | grep -w -- #{escape(version)}" if version
+        cmd
+      end
+
       def check_installed_by_pip(name, version=nil)
         regexp = "^#{name}"
         cmd = "pip list | grep -w -- #{escape(regexp)}"

--- a/spec/debian/package_spec.rb
+++ b/spec/debian/package_spec.rb
@@ -77,6 +77,11 @@ describe package('mongo') do
   it { should_not be_installed.by('pecl').with_version('invalid-version') }
 end
 
+describe package('XML_Util') do
+  it { should be_installed.by('pear').with_version('1.2.1') }
+  its(:command) { should eq "pear list | grep -w -- \\^XML_Util | grep -w -- 1.2.1" }
+end
+
 describe package('supervisor') do
   it { should be_installed.by('pip').with_version('3.0') }
   its(:command) { should eq "pip list | grep -w -- \\^supervisor | grep -w -- 3.0" }


### PR DESCRIPTION
define check_installed_by_pear
Usage: it { should be_installed.by('pear') }
