### PR TITLE
Make the exec backend return proper exitstatus.

### DIFF
--- a/lib/serverspec/backend/exec.rb
+++ b/lib/serverspec/backend/exec.rb
@@ -17,7 +17,7 @@ module Serverspec
         end
 
         { :stdout => stdout, :stderr => nil,
-          :exit_status => $?, :exit_signal => nil }
+          :exit_status => $?.exitstatus, :exit_signal => nil }
       end
 
       def build_command(cmd)


### PR DESCRIPTION
Before this pull request, `Serverspec::Backend::Exec#run_command` returns `$?` as exit status.
`$?` is an instance of `Process::Status`.

If `$?` is compared with an interger, `$?.to_i` will be compared with the value.
`Process::Status#to_i` doesn't return exit status but returns the bits in the status as Fixnum.

c.f.) http://www.ruby-doc.org/core-2.0.0/Process/Status.html
