### PR TITLE
[FreeBSD] replace pkg_version with pkg_info, for checking a package installed.

### DIFF
--- a/lib/serverspec/commands/freebsd.rb
+++ b/lib/serverspec/commands/freebsd.rb
@@ -6,7 +6,7 @@ module Serverspec
       end
 
       def check_installed(package, version=nil)
-        "pkg_version -X -s #{escape(package)}"
+        "pkg_info -Ix #{escape(package)}"
       end
 
       def check_listening(port)

--- a/spec/freebsd/package_spec.rb
+++ b/spec/freebsd/package_spec.rb
@@ -6,7 +6,7 @@ end
 
 describe package('httpd') do
   it { should be_installed }
-  its(:command) { should eq "pkg_version -X -s httpd" }
+  its(:command) { should eq "pkg_info -Ix httpd" }
 end
 
 describe package('invalid-package') do
@@ -15,7 +15,7 @@ end
 
 describe package('httpd') do
   it { should be_installed.with_version('2.2.15-28.el6') }
-  its(:command) { should eq "pkg_version -X -s httpd"}
+  its(:command) { should eq "pkg_info -Ix httpd"}
 end
 
 describe package('jekyll') do


### PR DESCRIPTION
It would be better to use **pkg_info** for checking whether a package is installed.

There is a reason why, 
- Both pkg_version and pkg_info are part of the base OS.
- pkg_info is faster than pkg_version, listing up installed packages.

```
$ time pkg_version -Xs zsh
zsh                                 =
pkg_version -Xs zsh  0.20s user 0.18s system 104% cpu 0.357 total

$ time pkg_info -Ix zsh
zsh-5.0.2_1         The Z shell
pkg_info -Ix zsh  0.01s user 0.01s system 94% cpu 0.017 total
```
