### PR TITLE
To be optional for \r (CR) because it may not be contained for the output of `ip route` on CentOS6.4 at least

### DIFF
--- a/lib/serverspec/type/default_gateway.rb
+++ b/lib/serverspec/type/default_gateway.rb
@@ -3,13 +3,13 @@ module Serverspec
     class DefaultGateway < Base
       def ipaddress
         ret = backend.run_command(commands.check_routing_table('default'))
-        ret[:stdout] =~ /^(\S+)(?: via (\S+))? dev (\S+).+\r\n(?:default via (\S+))?/
+        ret[:stdout] =~ /^(\S+)(?: via (\S+))? dev (\S+).+(?:\r)?\n(?:default via (\S+))?/
         $2 ? $2 : $4
       end
 
       def interface
         ret = backend.run_command(commands.check_routing_table('default'))
-        ret[:stdout] =~ /^(\S+)(?: via (\S+))? dev (\S+).+\r\n(?:default via (\S+))?/
+        ret[:stdout] =~ /^(\S+)(?: via (\S+))? dev (\S+).+(?:\r)?\n(?:default via (\S+))?/
         $3
       end
 


### PR DESCRIPTION
The reason why I fixed is that I saw \r (CR) wasn't contained in the output of `ip route`. 

```
[vagrant@dev test]$ cat /etc/redhat-release 
CentOS release 6.4 (Final)
[vagrant@dev test]$ ip route | grep -E '^default |^default ' | hexdump -C
00000000  64 65 66 61 75 6c 74 20  76 69 61 20 31 30 2e 30  |default via 10.0|
00000010  2e 32 2e 32 20 64 65 76  20 65 74 68 30 20 0a     |.2.2 dev eth0 .|
0000001f
```
