### PR TITLE
Replace CRLF with LF of STDOUT when SSH

### DIFF
--- a/lib/serverspec/backend/ssh.rb
+++ b/lib/serverspec/backend/ssh.rb
@@ -8,6 +8,8 @@ module Serverspec
         cmd = add_pre_command(cmd)
         ret = ssh_exec!(cmd)
 
+        ret[:stdout].gsub!(/\r\n/, "\n")
+
         if @example
           @example.metadata[:command] = cmd
           @example.metadata[:stdout]  = ret[:stdout]


### PR DESCRIPTION
Because SSH with pty allocation replaces LF with CRLF.
So serverspec should replace it to get original content.
