### PR TITLE
include tcp6 & udp6 as port protocol

### DIFF
--- a/lib/serverspec/type/port.rb
+++ b/lib/serverspec/type/port.rb
@@ -2,9 +2,9 @@ module Serverspec
   module Type
     class Port < Base
       def listening?(protocol)
-        if protocol 
+        if protocol
           protocol = protocol.to_s.downcase
-          unless ["udp", "tcp"].include?(protocol)
+          unless ["udp", "tcp", "tcp6", "udp6"].include?(protocol)
             raise ArgumentError.new("`be_listening` matcher doesn't support #{protocol}")
           end
 

--- a/spec/debian/port_spec.rb
+++ b/spec/debian/port_spec.rb
@@ -23,8 +23,18 @@ describe port(123) do
   its(:command) { should eq 'netstat -tunl | grep -- \\^udp\\ .\\*:123\\ ' }
 end
 
+describe port(81) do
+  it { should be_listening.with("tcp6") }
+  its(:command) { should eq 'netstat -tunl | grep -- \\^tcp6\\ .\\*:81\\ ' }
+end
+
+describe port(1234) do
+  it { should be_listening.with("udp6") }
+  its(:command) { should eq 'netstat -tunl | grep -- \\^udp6\\ .\\*:1234\\ ' }
+end
+
 describe port(80) do
-  it { 
+  it {
     expect {
       should be_listening.with('not implemented')
     }.to raise_error(ArgumentError, %r/\A`be_listening` matcher doesn\'t support/)


### PR DESCRIPTION
- apache2 in debian is listed as tcp6 in netstat so grep for 'tcp' won't
  work.
- removed some trailing spaces.
