### PR TITLE
Allow to use '_' and '-' as vagrant machine name

### DIFF
--- a/lib/serverspec/setup.rb
+++ b/lib/serverspec/setup.rb
@@ -189,7 +189,7 @@ EOF
         list_of_vms = []
         if vagrant_list != ''
           vagrant_list.each_line do |line|
-            if match = /([a-z]+[\s]+)(created|not created|poweroff|running|saved)[\s](\(virtualbox\)|\(vmware\))/.match(line)
+            if match = /([a-z_-]+[\s]+)(created|not created|poweroff|running|saved)[\s](\(virtualbox\)|\(vmware\))/.match(line)
               list_of_vms << match[1].strip!
             end
           end


### PR DESCRIPTION
Vagrantfile support in serverspec-init recognizes /[a-z]+/ as virtual machine name.
So that, when a machine name like "xxx_yyy-zzz" for example, serverspec-init recognizes the machine name as "zzz".

This pull request allows '-' and '_' as vagrant machine name.
