### PR TITLE
Remove check_running method of exec backend.

### DIFF
--- a/lib/serverspec/backend/exec.rb
+++ b/lib/serverspec/backend/exec.rb
@@ -39,22 +39,6 @@ module Serverspec
         cmd
       end
 
-      def check_running(process)
-        ret = run_command(commands.check_running(process))
-        
-        # In Ubuntu, some services are under upstart and "service foo status" returns
-        # exit status 0 even though they are stopped.
-        # So return false if stdout contains "stopped/waiting".
-        return false if ret[:stdout] =~ /stopped\/waiting/
-
-        # If the service is not registered, check by ps command
-        if ret[:exit_status] == 1
-          ret = run_command(commands.check_process(process))
-        end
-
-        ret[:exit_status] == 0
-      end
-
       def check_monitored_by_monit(process)
         ret = run_command(commands.check_monitored_by_monit(process))
         return false unless ret[:stdout] != nil && ret[:exit_status] == 0


### PR DESCRIPTION
`check_running` of `Exec` backend checks whether the service is running or not in the following way:
1. Check whether the service is running or not (e.g. `service status servicename` in ubuntu)
2. Check whether a process of the service is running or not (e.g. `ps aux | grep servicename`)

I removed Exec#check_running because this behaviour is different from the one of `Ssh` backend and it's confusing.
