### PR TITLE
fix freebsd spec (caused by specinfra changes)

### DIFF
--- a/spec/freebsd/file_spec.rb
+++ b/spec/freebsd/file_spec.rb
@@ -109,7 +109,7 @@ end
 describe file('/dev') do
   let(:stdout) { "755\r\n" }
   it { should be_readable }
-  its(:command) { should eq "stat -c %a /dev" }
+  its(:command) { should eq "stat -f %Lp /dev" }
 end
 
 describe file('/dev') do
@@ -150,7 +150,7 @@ end
 describe file('/dev') do
   let(:stdout) { "755\r\n" }
   it { should be_writable }
-  its(:command) { should eq "stat -c %a /dev" }
+  its(:command) { should eq "stat -f %Lp /dev" }
 end
 
 describe file('/dev') do


### PR DESCRIPTION
This test fail because in specinfra/lib/specinfra/command/freebsd.rb check_mode method use stat command with -f option for formatting. 
To fix this test, we should expect that command should contain -f option instead of -c option.
