### PR TITLE
remove waste spaces in spec

### DIFF
--- a/spec/freebsd/file_spec.rb
+++ b/spec/freebsd/file_spec.rb
@@ -109,7 +109,7 @@ end
 describe file('/dev') do
   let(:stdout) { "755\r\n" }
   it { should be_readable }
-  its(:command) { should eq "stat -f %Lp /dev" }
+  its(:command) { should eq "stat -f%Lp /dev" }
 end
 
 describe file('/dev') do
@@ -150,7 +150,7 @@ end
 describe file('/dev') do
   let(:stdout) { "755\r\n" }
   it { should be_writable }
-  its(:command) { should eq "stat -f %Lp /dev" }
+  its(:command) { should eq "stat -f%Lp /dev" }
 end
 
 describe file('/dev') do


### PR DESCRIPTION
Related to https://github.com/serverspec/serverspec/pull/306
Now should be ok.
$ rspec spec/freebsd/
........................................................................................................................................................................................................................................................

Finished in 0.1465 seconds
248 examples, 0 failures
