### PR TITLE
package: fix version comparison

### DIFF
--- a/spec/debian/package_spec.rb
+++ b/spec/debian/package_spec.rb
@@ -106,3 +106,25 @@ describe package('httpd') do
   its(:version) { should < '2.2.16' }
   its(:command) { should eq "dpkg-query -f '${Status} ${Version}' -W httpd | sed -n 's/^install ok installed //p'" }
 end
+
+# Debian-style versions
+describe package('httpd') do
+  let(:stdout) { "2.2.15-3\n" }
+  its(:version) { should eq '2.2.15-3' }
+  its(:version) { should > '2.2.15' }
+  its(:version) { should < '2.2.16' }
+  its(:version) { should < '2.2.15-4' }
+  its(:version) { should > '2.2.15-3~bpo70+1' }
+end
+
+# With some epoch
+describe package('httpd') do
+  let(:stdout) { "3:2.2.15-3~git20120918+ae4569bc\n" }
+  its(:version) { should eq '3:2.2.15-3~git20120918+ae4569bc' }
+  its(:version) { should > '3:2.2.15-3~git20120912+ae4569bc' }
+  its(:version) { should < '3:2.2.15-3' }
+  its(:version) { should < '3:2.2.15-3+feature1' }
+  its(:version) { should < '4:1.2.15' }
+  its(:version) { should > '2:4.2.15' }
+  its(:version) { should > '14.2.15' }
+end


### PR DESCRIPTION
`Gem::Version` does not accept the same versions that are usually used
in packages. Notably, packages like to define an upstream version and a
downstream version. For example, `2.2.4-15` is the 15th iteration of the
Apache 2.2.4 package.

With Debian, there are some more complex conventions:
- epoch is a way to use a smaller version number while ensuring strict
  increase of version numbers. For example, upstream was numbering with
  versions like 2011, 2012, 2013 and suddenly go back to a 1.2, 1.3
  versioning scheme. In this cases, distributions like Debian are using
  an epoch: 1:1.2, 1:1.3. Each time there is a problem with version
  numbering, epoch is increased. Default epoch is 0.
- tilde is a way to make a version smaller than any other versions
  sharing the same suffix. This is used when backporting a version to a
  previous version of the distribution. For example, you backport
  Apache 2.2.14-15, the version will be something like
  2.2.14-15~bpo60+1 which is inferior to 2.2.14-15 or
  2.2.14-15+something1.

The proposed implementation is quite basic, not widely tested but works
with the cases described above. Debian provides `libdpkg-rubyXX`
packages containing a more comprehensive way to compare version but this
would add a dependency. I believe that the proposed implementation is
equivalent with version numbers that can be found in the
wild.
