### PR TITLE
Refactor Serverspec::Type::Package::Version.

### DIFF
--- a/lib/serverspec/type/package.rb
+++ b/lib/serverspec/type/package.rb
@@ -47,7 +47,7 @@ module Serverspec
         end
 
         def ver_array
-          val = @version.dup
+          val = @version
           re = /^(?:(\d+)|(\D+))(.*)$/
           res = []
           while !val.empty?


### PR DESCRIPTION
- To make more object-oriented, I changed arity of `Version#ver_array`
- Remove `#dup` because the instance is not modified in the method.
