### PR TITLE
Allow to test process parameters

### DIFF
--- a/lib/serverspec/helper/type.rb
+++ b/lib/serverspec/helper/type.rb
@@ -4,7 +4,7 @@ module Serverspec
       types = %w(
         base cgroup command cron default_gateway file group host interface
         ipfilter ipnat iptables kernel_module linux_kernel_parameter lxc mail_alias
-        package php_config port routing_table selinux service user yumrepo
+        package php_config port process routing_table selinux service user yumrepo
         windows_registry_key zfs
       )
 

--- a/lib/serverspec/matchers/be_running.rb
+++ b/lib/serverspec/matchers/be_running.rb
@@ -1,6 +1,10 @@
 RSpec::Matchers.define :be_running do
   match do |process|
-    process.running?(@under)
+    if subject.class.name == 'Serverspec::Type::Service'
+      process.running?(@under)
+    else
+      process.running?
+    end
   end
 
   chain :under do |under|

--- a/lib/serverspec/type/lxc.rb
+++ b/lib/serverspec/type/lxc.rb
@@ -5,7 +5,7 @@ module Serverspec
         backend.check_container(@name)
       end
 
-      def running?(under)
+      def running?
         backend.check_container_running(@name)
       end
 

--- a/lib/serverspec/type/process.rb
+++ b/lib/serverspec/type/process.rb
@@ -1,0 +1,23 @@
+module Serverspec
+  module Type
+    class Process < Base
+
+      def running?
+        pid = backend.run_command(commands.get_process(@name, "pid"))[:stdout]
+        not pid.empty?
+      end
+
+      def to_ary
+        ["process", @name]
+      end
+
+      def method_missing(meth)
+        ret = backend.run_command(commands.get_process(@name, meth.to_s))
+        val = ret[:stdout].strip
+        val = val.to_i if val.match(/^\d+$/)
+        val
+      end
+
+    end
+  end
+end

--- a/spec/aix/process_spec.rb
+++ b/spec/aix/process_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+include SpecInfra::Helper::AIX
+
+describe process("memcached") do
+  let(:stdout) { " 1407\n" }
+  its(:pid) { should eq 1407 }
+  its(:command) { should eq "ps -C memcached -o pid= | head -1" }
+end
+
+describe process("memcached") do
+  let(:stdout) { "/usr/bin/memcached -m 14386 -p 11211 -u nobody -l 10.11.1.53 -c 30000\n" }
+  its(:args) { should match /-c 30000\b/ }
+  its(:command) { should eq "ps -C memcached -o args= | head -1" }
+end
+
+describe process("memcached") do
+  context "when running" do
+    let(:stdout) { " 1407\n" }
+    it { should be_running }
+    its(:command) { should eq "ps -C memcached -o pid= | head -1" }
+  end
+
+  context "when not running" do
+    let(:stdout) { " 1407\n" }
+    it { should be_running }
+    its(:command) { should eq "ps -C memcached -o pid= | head -1" }
+  end
+end

--- a/spec/darwin/process_spec.rb
+++ b/spec/darwin/process_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+include SpecInfra::Helper::Darwin
+
+describe process("memcached") do
+  let(:stdout) { " 1407\n" }
+  its(:pid) { should eq 1407 }
+  its(:command) { should eq "ps -C memcached -o pid= | head -1" }
+end
+
+describe process("memcached") do
+  let(:stdout) { "/usr/bin/memcached -m 14386 -p 11211 -u nobody -l 10.11.1.53 -c 30000\n" }
+  its(:args) { should match /-c 30000\b/ }
+  its(:command) { should eq "ps -C memcached -o args= | head -1" }
+end
+
+describe process("memcached") do
+  context "when running" do
+    let(:stdout) { " 1407\n" }
+    it { should be_running }
+    its(:command) { should eq "ps -C memcached -o pid= | head -1" }
+  end
+
+  context "when not running" do
+    let(:stdout) { " 1407\n" }
+    it { should be_running }
+    its(:command) { should eq "ps -C memcached -o pid= | head -1" }
+  end
+end

--- a/spec/debian/process_spec.rb
+++ b/spec/debian/process_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+include SpecInfra::Helper::Debian
+
+describe process("memcached") do
+  let(:stdout) { " 1407\n" }
+  its(:pid) { should eq 1407 }
+  its(:command) { should eq "ps -C memcached -o pid= | head -1" }
+end
+
+describe process("memcached") do
+  let(:stdout) { "/usr/bin/memcached -m 14386 -p 11211 -u nobody -l 10.11.1.53 -c 30000\n" }
+  its(:args) { should match /-c 30000\b/ }
+  its(:command) { should eq "ps -C memcached -o args= | head -1" }
+end
+
+describe process("memcached") do
+  context "when running" do
+    let(:stdout) { " 1407\n" }
+    it { should be_running }
+    its(:command) { should eq "ps -C memcached -o pid= | head -1" }
+  end
+
+  context "when not running" do
+    let(:stdout) { " 1407\n" }
+    it { should be_running }
+    its(:command) { should eq "ps -C memcached -o pid= | head -1" }
+  end
+end

--- a/spec/freebsd/process_spec.rb
+++ b/spec/freebsd/process_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+include SpecInfra::Helper::FreeBSD
+
+describe process("memcached") do
+  let(:stdout) { " 1407\n" }
+  its(:pid) { should eq 1407 }
+  its(:command) { should eq "ps -C memcached -o pid= | head -1" }
+end
+
+describe process("memcached") do
+  let(:stdout) { "/usr/bin/memcached -m 14386 -p 11211 -u nobody -l 10.11.1.53 -c 30000\n" }
+  its(:args) { should match /-c 30000\b/ }
+  its(:command) { should eq "ps -C memcached -o args= | head -1" }
+end
+
+describe process("memcached") do
+  context "when running" do
+    let(:stdout) { " 1407\n" }
+    it { should be_running }
+    its(:command) { should eq "ps -C memcached -o pid= | head -1" }
+  end
+
+  context "when not running" do
+    let(:stdout) { " 1407\n" }
+    it { should be_running }
+    its(:command) { should eq "ps -C memcached -o pid= | head -1" }
+  end
+end

--- a/spec/gentoo/process_spec.rb
+++ b/spec/gentoo/process_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+include SpecInfra::Helper::Gentoo
+
+describe process("memcached") do
+  let(:stdout) { " 1407\n" }
+  its(:pid) { should eq 1407 }
+  its(:command) { should eq "ps -C memcached -o pid= | head -1" }
+end
+
+describe process("memcached") do
+  let(:stdout) { "/usr/bin/memcached -m 14386 -p 11211 -u nobody -l 10.11.1.53 -c 30000\n" }
+  its(:args) { should match /-c 30000\b/ }
+  its(:command) { should eq "ps -C memcached -o args= | head -1" }
+end
+
+describe process("memcached") do
+  context "when running" do
+    let(:stdout) { " 1407\n" }
+    it { should be_running }
+    its(:command) { should eq "ps -C memcached -o pid= | head -1" }
+  end
+
+  context "when not running" do
+    let(:stdout) { " 1407\n" }
+    it { should be_running }
+    its(:command) { should eq "ps -C memcached -o pid= | head -1" }
+  end
+end

--- a/spec/redhat/process_spec.rb
+++ b/spec/redhat/process_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+include SpecInfra::Helper::RedHat
+
+describe process("memcached") do
+  let(:stdout) { " 1407\n" }
+  its(:pid) { should eq 1407 }
+  its(:command) { should eq "ps -C memcached -o pid= | head -1" }
+end
+
+describe process("memcached") do
+  let(:stdout) { "/usr/bin/memcached -m 14386 -p 11211 -u nobody -l 10.11.1.53 -c 30000\n" }
+  its(:args) { should match /-c 30000\b/ }
+  its(:command) { should eq "ps -C memcached -o args= | head -1" }
+end
+
+describe process("memcached") do
+  context "when running" do
+    let(:stdout) { " 1407\n" }
+    it { should be_running }
+    its(:command) { should eq "ps -C memcached -o pid= | head -1" }
+  end
+
+  context "when not running" do
+    let(:stdout) { " 1407\n" }
+    it { should be_running }
+    its(:command) { should eq "ps -C memcached -o pid= | head -1" }
+  end
+end

--- a/spec/smartos/process_spec.rb
+++ b/spec/smartos/process_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+include SpecInfra::Helper::SmartOS
+
+describe process("memcached") do
+  let(:stdout) { " 1407\n" }
+  its(:pid) { should eq 1407 }
+  its(:command) { should eq "ps -C memcached -o pid= | head -1" }
+end
+
+describe process("memcached") do
+  let(:stdout) { "/usr/bin/memcached -m 14386 -p 11211 -u nobody -l 10.11.1.53 -c 30000\n" }
+  its(:args) { should match /-c 30000\b/ }
+  its(:command) { should eq "ps -C memcached -o args= | head -1" }
+end
+
+describe process("memcached") do
+  context "when running" do
+    let(:stdout) { " 1407\n" }
+    it { should be_running }
+    its(:command) { should eq "ps -C memcached -o pid= | head -1" }
+  end
+
+  context "when not running" do
+    let(:stdout) { " 1407\n" }
+    it { should be_running }
+    its(:command) { should eq "ps -C memcached -o pid= | head -1" }
+  end
+end

--- a/spec/solaris/process_spec.rb
+++ b/spec/solaris/process_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+include SpecInfra::Helper::Solaris
+
+describe process("memcached") do
+  let(:stdout) { " 1407\n" }
+  its(:pid) { should eq 1407 }
+  its(:command) { should eq "ps -C memcached -o pid= | head -1" }
+end
+
+describe process("memcached") do
+  let(:stdout) { "/usr/bin/memcached -m 14386 -p 11211 -u nobody -l 10.11.1.53 -c 30000\n" }
+  its(:args) { should match /-c 30000\b/ }
+  its(:command) { should eq "ps -C memcached -o args= | head -1" }
+end
+
+describe process("memcached") do
+  context "when running" do
+    let(:stdout) { " 1407\n" }
+    it { should be_running }
+    its(:command) { should eq "ps -C memcached -o pid= | head -1" }
+  end
+
+  context "when not running" do
+    let(:stdout) { " 1407\n" }
+    it { should be_running }
+    its(:command) { should eq "ps -C memcached -o pid= | head -1" }
+  end
+end


### PR DESCRIPTION
Any parameter that can be queried with `ps` can be used for tests. For
example:

```
describe process("memcached") do
  its(:args) { should match /-c 30000\b/ }
end
```

There is a commit needed in specinfra for this to work. Moreover, I had to define `to_ary` in `Process` class. I don't know how `Cgroup` class got to work without it.
