### PR TITLE
Add to_ary to Serverspec::Type::Base

### DIFF
--- a/lib/serverspec/type/base.rb
+++ b/lib/serverspec/type/base.rb
@@ -13,6 +13,10 @@ module Serverspec
       end
 
       alias_method :inspect, :to_s
+
+      def to_ary
+        to_s.split(" ")
+      end
     end
   end
 end

--- a/lib/serverspec/type/process.rb
+++ b/lib/serverspec/type/process.rb
@@ -7,10 +7,6 @@ module Serverspec
         not pid.empty?
       end
 
-      def to_ary
-        ["process", @name]
-      end
-
       def method_missing(meth)
         ret = backend.run_command(commands.get_process(@name, :format => "#{meth.to_s}="))
         val = ret[:stdout].strip


### PR DESCRIPTION
Because it's needed to json format reporter.
