### PR TITLE
Quick fix for #324

### DIFF
--- a/lib/serverspec/type/service.rb
+++ b/lib/serverspec/type/service.rb
@@ -5,7 +5,7 @@ module Serverspec
         backend.check_enabled(@name, level)
       end
 
-      def running?(under)
+      def running?(under=nil)
         if under
           check_method = "check_running_under_#{under}".to_sym
 


### PR DESCRIPTION
As reported by #324, this code doesn't work since v0.14.0.

``` ruby
describe 'sshd daemon' do
  it 'has a running service of ssh' do
    expect(service('ssh')).to be_running
  end
end
```

It seems that `expect` notation does not call custom matchers.

One-liner `should` notation works fine.
