### PR TITLE
Subject should be serverspec resource type class

### DIFF
--- a/lib/serverspec/matchers/be_running.rb
+++ b/lib/serverspec/matchers/be_running.rb
@@ -1,9 +1,9 @@
 RSpec::Matchers.define :be_running do
-  match do |process|
+  match do |subject|
     if subject.class.name == 'Serverspec::Type::Service'
-      process.running?(@under)
+      subject.running?(@under)
     else
-      process.running?
+      subject.running?
     end
   end
 

--- a/lib/serverspec/type/service.rb
+++ b/lib/serverspec/type/service.rb
@@ -5,7 +5,7 @@ module Serverspec
         backend.check_enabled(@name, level)
       end
 
-      def running?(under=nil)
+      def running?(under)
         if under
           check_method = "check_running_under_#{under}".to_sym
 


### PR DESCRIPTION
In #325, I wrote "Custom matchers should not check the subject class".

But it's not correct.

Custom matchers should check the class of the argument of match block.

I use `subject` as the argument name and it is same as the method name
within RSpec.So it's confusing.

I should not use the name `subject`, but keep them tentatively.
