### PR TITLE
Change regex to match more vagrant machine names

### DIFF
--- a/lib/serverspec/setup.rb
+++ b/lib/serverspec/setup.rb
@@ -189,7 +189,7 @@ EOF
         list_of_vms = []
         if vagrant_list != ''
           vagrant_list.each_line do |line|
-            if match = /([a-z_-]+[\s]+)(created|not created|poweroff|running|saved)[\s](\(virtualbox\)|\(vmware\))/.match(line)
+            if match = /([\w-]+[\s]+)(created|not created|poweroff|running|saved)[\s](\(virtualbox\)|\(vmware\))/.match(line)
               list_of_vms << match[1].strip!
             end
           end


### PR DESCRIPTION
serverspec-init recognizes `/[a-z_-]+/` as vagrant machine name.
So, it cannot recognize machine name that contains digits or uppercase letters : 

```
$ cat Vagrantfile
Vagrant.configure('2') do |config|
  config.vm.define 'app1'
  config.vm.define 'DB'
end
$ serverspec-init
...
Vagrant instance y/n: y
Auto-configure Vagrant from Vagrantfile? y/n: y
0) not
1) not
```

This pull request updates vagrant machine name regex to support name that contains digits or uppercase letters.
