### PR TITLE
Fix syntax error for Ruby 1.8.7

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -59,6 +59,6 @@ task 'create_release' => 'release' do
   Octokit.create_release(
     repo,
     current_version,
-    body: description.join("\n"),
+    {:body => description.join("\n")}
   )
 end


### PR DESCRIPTION
Ruby 1.8.7 cannot use the Hash literal syntax available in version 1.9 or higher.

[Travis build failed on rvm 1.8.7](https://travis-ci.org/serverspec/serverspec/jobs/17889998)
