### PR TITLE
Check the Windows metadata version of a file

### DIFF
--- a/lib/serverspec/type/file.rb
+++ b/lib/serverspec/type/file.rb
@@ -81,6 +81,10 @@ module Serverspec
         end
         @content
       end
+
+      def version?(version)
+          backend.check_file_version(@name, version)
+      end
     end
   end
 end


### PR DESCRIPTION
Adds the ability to check if a dll/exe's product/file version matches a version string

```
describe file("C:/Windows/System32/aaclient.dll") do
    it{ should be_file }
    it{ should be_version("6.2.9200.16398") }
end 
```
