### PR TITLE
use its(:content) at a sample spec

### DIFF
--- a/lib/serverspec/setup.rb
+++ b/lib/serverspec/setup.rb
@@ -109,7 +109,7 @@ end
 
 describe file('/etc/httpd/conf/httpd.conf') do
   it { should be_file }
-  it { should contain "ServerName #{@hostname}" }
+  its(:content) { should match /ServerName #{@hostname}/ }
 end
 EOF
 


### PR DESCRIPTION
it uses `its(:content)` like http://serverspec.org/resource_types.html#file instead of `contain`.
