### PR TITLE
substitute pkgng for pkg_info

### DIFF
--- a/spec/freebsd/package_spec.rb
+++ b/spec/freebsd/package_spec.rb
@@ -4,7 +4,7 @@ include SpecInfra::Helper::FreeBSD
 
 describe package('httpd') do
   it { should be_installed }
-  its(:command) { should eq "pkg_info -Ix httpd" }
+  its(:command) { should eq "pkg info httpd" }
 end
 
 describe package('invalid-package') do
@@ -13,7 +13,7 @@ end
 
 describe package('httpd') do
   it { should be_installed.with_version('2.2.15-28.el6') }
-  its(:command) { should eq "pkg_info -Ix httpd"}
+  its(:command) { should eq "pkg query %v httpd"}
 end
 
 describe package('jekyll') do


### PR DESCRIPTION
"**pkgng**" is the new package manager.
  see http://www.freebsd.org/doc/en/books/handbook/pkgng-intro.html

I suppose it should use **pkgng** instead of `pkg_info`, `pkg_add`, and such.
**pkgng** supports FreeBSD 9.1 over, and moreover, `pkg_info` and such have
been removed since FreeBSD 10.0-CURRENT.
