### PR TITLE
the Rakefile template runs the tests as the default task

### DIFF
--- a/lib/serverspec/setup.rb
+++ b/lib/serverspec/setup.rb
@@ -161,7 +161,9 @@ require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec) do |t|
   t.pattern = 'spec/*/*_spec.rb'
 end
-EOF
+
+task :default => :spec
+      EOF
       if File.exists? 'Rakefile'
         old_content = File.read('Rakefile')
         if old_content != content


### PR DESCRIPTION
This sets the default task to run the tests so only `$ rake` is needed.

(I think that RSpec's error in the case of no default task being set to be confusing for those new to Ruby/RSpec). 
