### PR TITLE
this serverspec version does not work w/ rspec-3.0

### DIFF
--- a/serverspec.gemspec
+++ b/serverspec.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "net-ssh"
-  spec.add_runtime_dependency "rspec", ">= 2.13.0"
+  spec.add_runtime_dependency "rspec", "~> 2.13"
   spec.add_runtime_dependency "highline"
   spec.add_runtime_dependency "specinfra", ">= 0.7.1"
   spec.add_development_dependency "bundler", "~> 1.3"


### PR DESCRIPTION
Rspec 3.x (currently 3.0.0-beta2) have no compatibilities for `require 'rspec'`, `require 'rspec/its'` and so on.
Serverspec should claim its gemspec w/ Rspec 2.x explicitly.
