### PR TITLE
Do not merge stdout/stderr.

### DIFF
--- a/lib/serverspec/type/command.rb
+++ b/lib/serverspec/type/command.rb
@@ -14,13 +14,10 @@ module Serverspec
 
       def return_stderr?(content)
         ret = backend.run_command(@name)
-        # In ssh access with pty, stderr is merged to stdout
-        # See http://stackoverflow.com/questions/7937651/receiving-extended-data-with-ssh-using-twisted-conch-as-client
-        # So I use stdout instead of stderr
         if content.instance_of?(Regexp)
-          ret.stdout =~ content
+          ret.stderr =~ content
         else
-          ret.stdout.strip == content
+          ret.stderr.strip == content
         end
       end
 
@@ -36,10 +33,12 @@ module Serverspec
         @result
       end
 
-      # In ssh access with pty, stderr is merged to stdout
-      # See http://stackoverflow.com/questions/7937651/receiving-extended-data-with-ssh-using-twisted-conch-as-client
-      # So I use stdout instead of stderr
-      alias :stderr :stdout
+      def stderr
+        if @result.nil?
+          @result = backend.run_command(@name).stderr
+        end
+        @result
+      end
     end
   end
 end

--- a/spec/aix/command_spec.rb
+++ b/spec/aix/command_spec.rb
@@ -23,21 +23,21 @@ describe 'regexp matching of stdout' do
 end
 
 describe command('cat /etc/resolv.conf') do
-  let(:stdout) { "No such file or directory\r\n" }
+  let(:stderr) { "No such file or directory\r\n" }
   it { should return_stderr("No such file or directory") }
   its(:command) { should eq 'cat /etc/resolv.conf' }
 end
 
 describe 'complete matching of stderr' do
   context command('cat /etc/resolv.conf') do
-    let(:stdout) { "No such file or directory\r\n" }
-    it { should_not return_stdout('file') }
+    let(:stderr) { "No such file or directory\r\n" }
+    it { should_not return_stderr('file') }
   end
 end
 
 describe 'regexp matching of stderr' do
   context command('cat /etc/resolv.conf') do
-    let(:stdout) { "No such file or directory\r\n" }
+    let(:stderr) { "No such file or directory\r\n" }
     it { should return_stderr(/file/) }
   end
 end
@@ -61,7 +61,5 @@ EOF
     }
 
   its(:stdout) { should match /bin/ }
-  its(:stderr) { should match /bin/ }
-
   its(:stdout) { should eq stdout }
 end

--- a/spec/darwin/command_spec.rb
+++ b/spec/darwin/command_spec.rb
@@ -23,21 +23,21 @@ describe 'regexp matching of stdout' do
 end
 
 describe command('cat /etc/resolv.conf') do
-  let(:stdout) { "No such file or directory\r\n" }
+  let(:stderr) { "No such file or directory\r\n" }
   it { should return_stderr("No such file or directory") }
   its(:command) { should eq 'cat /etc/resolv.conf' }
 end
 
 describe 'complete matching of stderr' do
   context command('cat /etc/resolv.conf') do
-    let(:stdout) { "No such file or directory\r\n" }
-    it { should_not return_stdout('file') }
+    let(:stderr) { "No such file or directory\r\n" }
+    it { should_not return_stderr('file') }
   end
 end
 
 describe 'regexp matching of stderr' do
   context command('cat /etc/resolv.conf') do
-    let(:stdout) { "No such file or directory\r\n" }
+    let(:stderr) { "No such file or directory\r\n" }
     it { should return_stderr(/file/) }
   end
 end
@@ -61,7 +61,5 @@ EOF
     }
 
   its(:stdout) { should match /bin/ }
-  its(:stderr) { should match /bin/ }
-
   its(:stdout) { should eq stdout }
 end

--- a/spec/debian/command_spec.rb
+++ b/spec/debian/command_spec.rb
@@ -23,21 +23,21 @@ describe 'regexp matching of stdout' do
 end
 
 describe command('cat /etc/resolv.conf') do
-  let(:stdout) { "No such file or directory\r\n" }
+  let(:stderr) { "No such file or directory\r\n" }
   it { should return_stderr("No such file or directory") }
   its(:command) { should eq 'cat /etc/resolv.conf' }
 end
 
 describe 'complete matching of stderr' do
   context command('cat /etc/resolv.conf') do
-    let(:stdout) { "No such file or directory\r\n" }
-    it { should_not return_stdout('file') }
+    let(:stderr) { "No such file or directory\r\n" }
+    it { should_not return_stderr('file') }
   end
 end
 
 describe 'regexp matching of stderr' do
   context command('cat /etc/resolv.conf') do
-    let(:stdout) { "No such file or directory\r\n" }
+    let(:stderr) { "No such file or directory\r\n" }
     it { should return_stderr(/file/) }
   end
 end
@@ -61,7 +61,5 @@ EOF
     }
 
   its(:stdout) { should match /bin/ }
-  its(:stderr) { should match /bin/ }
-
   its(:stdout) { should eq stdout }
 end

--- a/spec/freebsd/command_spec.rb
+++ b/spec/freebsd/command_spec.rb
@@ -23,21 +23,21 @@ describe 'regexp matching of stdout' do
 end
 
 describe command('cat /etc/resolv.conf') do
-  let(:stdout) { "No such file or directory\r\n" }
+  let(:stderr) { "No such file or directory\r\n" }
   it { should return_stderr("No such file or directory") }
   its(:command) { should eq 'cat /etc/resolv.conf' }
 end
 
 describe 'complete matching of stderr' do
   context command('cat /etc/resolv.conf') do
-    let(:stdout) { "No such file or directory\r\n" }
-    it { should_not return_stdout('file') }
+    let(:stderr) { "No such file or directory\r\n" }
+    it { should_not return_stderr('file') }
   end
 end
 
 describe 'regexp matching of stderr' do
   context command('cat /etc/resolv.conf') do
-    let(:stdout) { "No such file or directory\r\n" }
+    let(:stderr) { "No such file or directory\r\n" }
     it { should return_stderr(/file/) }
   end
 end
@@ -61,7 +61,5 @@ EOF
     }
 
   its(:stdout) { should match /bin/ }
-  its(:stderr) { should match /bin/ }
-
   its(:stdout) { should eq stdout }
 end

--- a/spec/gentoo/command_spec.rb
+++ b/spec/gentoo/command_spec.rb
@@ -23,21 +23,21 @@ describe 'regexp matching of stdout' do
 end
 
 describe command('cat /etc/resolv.conf') do
-  let(:stdout) { "No such file or directory\r\n" }
+  let(:stderr) { "No such file or directory\r\n" }
   it { should return_stderr("No such file or directory") }
   its(:command) { should eq 'cat /etc/resolv.conf' }
 end
 
 describe 'complete matching of stderr' do
   context command('cat /etc/resolv.conf') do
-    let(:stdout) { "No such file or directory\r\n" }
-    it { should_not return_stdout('file') }
+    let(:stderr) { "No such file or directory\r\n" }
+    it { should_not return_stderr('file') }
   end
 end
 
 describe 'regexp matching of stderr' do
   context command('cat /etc/resolv.conf') do
-    let(:stdout) { "No such file or directory\r\n" }
+    let(:stderr) { "No such file or directory\r\n" }
     it { should return_stderr(/file/) }
   end
 end
@@ -61,7 +61,5 @@ EOF
     }
 
   its(:stdout) { should match /bin/ }
-  its(:stderr) { should match /bin/ }
-
   its(:stdout) { should eq stdout }
 end

--- a/spec/plamo/command_spec.rb
+++ b/spec/plamo/command_spec.rb
@@ -23,21 +23,21 @@ describe 'regexp matching of stdout' do
 end
 
 describe command('cat /etc/resolv.conf') do
-  let(:stdout) { "No such file or directory\r\n" }
+  let(:stderr) { "No such file or directory\r\n" }
   it { should return_stderr("No such file or directory") }
   its(:command) { should eq 'cat /etc/resolv.conf' }
 end
 
 describe 'complete matching of stderr' do
   context command('cat /etc/resolv.conf') do
-    let(:stdout) { "No such file or directory\r\n" }
-    it { should_not return_stdout('file') }
+    let(:stderr) { "No such file or directory\r\n" }
+    it { should_not return_stderr('file') }
   end
 end
 
 describe 'regexp matching of stderr' do
   context command('cat /etc/resolv.conf') do
-    let(:stdout) { "No such file or directory\r\n" }
+    let(:stderr) { "No such file or directory\r\n" }
     it { should return_stderr(/file/) }
   end
 end
@@ -61,7 +61,5 @@ EOF
     }
 
   its(:stdout) { should match /bin/ }
-  its(:stderr) { should match /bin/ }
-
   its(:stdout) { should eq stdout }
 end

--- a/spec/redhat/command_spec.rb
+++ b/spec/redhat/command_spec.rb
@@ -24,21 +24,21 @@ describe 'regexp matching of stdout' do
 end
 
 describe command('cat /etc/resolv.conf') do
-  let(:stdout) { "No such file or directory\r\n" }
+  let(:stderr) { "No such file or directory\r\n" }
   it { should return_stderr("No such file or directory") }
   its(:command) { should eq 'cat /etc/resolv.conf' }
 end
 
 describe 'complete matching of stderr' do
   context command('cat /etc/resolv.conf') do
-    let(:stdout) { "No such file or directory\r\n" }
-    it { should_not return_stdout('file') }
+    let(:stderr) { "No such file or directory\r\n" }
+    it { should_not return_stderr('file') }
   end
 end
 
 describe 'regexp matching of stderr' do
   context command('cat /etc/resolv.conf') do
-    let(:stdout) { "No such file or directory\r\n" }
+    let(:stderr) { "No such file or directory\r\n" }
     it { should return_stderr(/file/) }
   end
 end
@@ -63,7 +63,5 @@ EOF
     }
 
   its(:stdout) { should match /bin/ }
-  its(:stderr) { should match /bin/ }
-
   its(:stdout) { should eq stdout }
 end

--- a/spec/solaris/command_spec.rb
+++ b/spec/solaris/command_spec.rb
@@ -23,21 +23,21 @@ describe 'regexp matching of stdout' do
 end
 
 describe command('cat /etc/resolv.conf') do
-  let(:stdout) { "No such file or directory\r\n" }
+  let(:stderr) { "No such file or directory\r\n" }
   it { should return_stderr("No such file or directory") }
   its(:command) { should eq 'cat /etc/resolv.conf' }
 end
 
 describe 'complete matching of stderr' do
   context command('cat /etc/resolv.conf') do
-    let(:stdout) { "No such file or directory\r\n" }
-    it { should_not return_stdout('file') }
+    let(:stderr) { "No such file or directory\r\n" }
+    it { should_not return_stderr('file') }
   end
 end
 
 describe 'regexp matching of stderr' do
   context command('cat /etc/resolv.conf') do
-    let(:stdout) { "No such file or directory\r\n" }
+    let(:stderr) { "No such file or directory\r\n" }
     it { should return_stderr(/file/) }
   end
 end
@@ -61,7 +61,5 @@ EOF
     }
 
   its(:stdout) { should match /bin/ }
-  its(:stderr) { should match /bin/ }
-
   its(:stdout) { should eq stdout }
 end

--- a/spec/solaris11/command_spec.rb
+++ b/spec/solaris11/command_spec.rb
@@ -23,21 +23,21 @@ describe 'regexp matching of stdout' do
 end
 
 describe command('cat /etc/resolv.conf') do
-  let(:stdout) { "No such file or directory\r\n" }
+  let(:stderr) { "No such file or directory\r\n" }
   it { should return_stderr("No such file or directory") }
   its(:command) { should eq 'cat /etc/resolv.conf' }
 end
 
 describe 'complete matching of stderr' do
   context command('cat /etc/resolv.conf') do
-    let(:stdout) { "No such file or directory\r\n" }
-    it { should_not return_stdout('file') }
+    let(:stderr) { "No such file or directory\r\n" }
+    it { should_not return_stderr('file') }
   end
 end
 
 describe 'regexp matching of stderr' do
   context command('cat /etc/resolv.conf') do
-    let(:stdout) { "No such file or directory\r\n" }
+    let(:stderr) { "No such file or directory\r\n" }
     it { should return_stderr(/file/) }
   end
 end
@@ -61,7 +61,5 @@ EOF
     }
 
   its(:stdout) { should match /bin/ }
-  its(:stderr) { should match /bin/ }
-
   its(:stdout) { should eq stdout }
 end

--- a/spec/windows/command_spec.rb
+++ b/spec/windows/command_spec.rb
@@ -24,21 +24,21 @@ describe 'regexp matching of stdout' do
 end
 
 describe command('test_cmd /test/path/file') do
-  let(:stdout) { "No such file or directory\r\n" }
+  let(:stderr) { "No such file or directory\r\n" }
   it { should return_stderr("No such file or directory") }
   its(:command) { should eq 'test_cmd /test/path/file' }
 end
 
 describe 'complete matching of stderr' do
   context command('test_cmd /test/path/file') do
-    let(:stdout) { "No such file or directory\r\n" }
-    it { should_not return_stdout('file') }
+    let(:stderr) { "No such file or directory\r\n" }
+    it { should_not return_stderr('file') }
   end
 end
 
 describe 'regexp matching of stderr' do
   context command('test_cmd /test/path/file') do
-    let(:stdout) { "No such file or directory\r\n" }
+    let(:stderr) { "No such file or directory\r\n" }
     it { should return_stderr(/file/) }
   end
 end
@@ -63,7 +63,5 @@ EOF
     }
 
   its(:stdout) { should match /Program Files/ }
-  its(:stderr) { should match /Program Files/ }
-
   its(:stdout) { should eq stdout }
 end


### PR DESCRIPTION
The reason of the merge was the fact that when SSH was requesting a PTY,
stdout/stderr were merged. However, the use of PTY was made
optional (only used for sudo password) in this commit:
 https://github.com/serverspec/specinfra/commit/b4153a7f4f79cfcf5b1d91ebf77da66bd3e76b78

Therefore, we now need to access the true stderr for tests to work as
expected.

The user has to know if he should use stdout or stderr for its
tests. The documentation may state that the use of sudo password will
merge stdout and stderr.
