### PR TITLE
Don't conflate stdout and stderr; run commands once

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,8 +6,9 @@ task :spec => 'spec:all'
 
 namespace :spec do
   oses = %w( darwin debian gentoo plamo redhat aix solaris solaris10 solaris11 smartos windows freebsd freebsd10)
+  backends = %w( exec ssh cmd winrm powershell )
 
-  task :all => [ oses.map {|os| "spec:#{os}" }, :exec, :ssh, :cmd, :winrm, :powershell, :helper ].flatten
+  task :all => [ oses.map {|os| "spec:#{os}" }, backends, :helper, :unit ].flatten
 
   oses.each do |os|
     RSpec::Core::RakeTask.new(os.to_sym) do |t|
@@ -15,7 +16,7 @@ namespace :spec do
     end
   end
 
-  [:exec, :ssh, :cmd, :winrm, :powershell].each do |backend|
+  backends.each do |backend|
     RSpec::Core::RakeTask.new(backend) do |t|
       t.pattern = "spec/backend/#{backend.to_s}/*_spec.rb"
     end
@@ -23,5 +24,9 @@ namespace :spec do
 
   RSpec::Core::RakeTask.new(:helper) do |t|
     t.pattern = "spec/helper/*_spec.rb"
+  end
+
+  RSpec::Core::RakeTask.new(:unit) do |t|
+    t.pattern = "spec/unit/*_spec.rb"
   end
 end

--- a/lib/serverspec/type/command.rb
+++ b/lib/serverspec/type/command.rb
@@ -1,43 +1,42 @@
 module Serverspec
   module Type
     class Command < Base
-      attr_accessor :result
-
       def return_stdout?(content)
-        ret = backend.run_command(@name)
         if content.instance_of?(Regexp)
-          ret.stdout =~ content
+          stdout =~ content
         else
-          ret.stdout.strip == content
+          stdout.strip == content
         end
       end
 
       def return_stderr?(content)
-        ret = backend.run_command(@name)
         if content.instance_of?(Regexp)
-          ret.stderr =~ content
+          stderr =~ content
         else
-          ret.stderr.strip == content
+          stderr.strip == content
         end
       end
 
       def return_exit_status?(status)
-        ret = backend.run_command(@name)
-        ret.exit_status.to_i == status
+        exit_status == status
       end
 
       def stdout
-        if @result.nil?
-          @result = backend.run_command(@name).stdout
-        end
-        @result
+        command_result.stdout
       end
 
       def stderr
-        if @result.nil?
-          @result = backend.run_command(@name).stderr
-        end
-        @result
+        command_result.stderr
+      end
+
+      def exit_status
+        command_result.exit_status.to_i
+      end
+
+      private
+
+      def command_result()
+	@command_result ||= backend.run_command(@name)
       end
     end
   end

--- a/spec/unit/command_spec.rb
+++ b/spec/unit/command_spec.rb
@@ -1,0 +1,81 @@
+require 'spec_helper'
+
+describe Serverspec::Type::Command do
+  subject { command('echo banana') }
+
+  before :each do
+    allow(subject.backend).to receive(:run_command).and_return(
+        CommandResult.new({
+          :stdout      => "banana\n",
+          :stderr      => "split\n",
+          :exit_status => "42",         # Command should convert this to an integer
+        })
+    )
+  end
+
+  it 'has stdout' do
+    expect(subject.stdout).to be == "banana\n"
+  end
+
+  it 'has stderr' do
+    expect(subject.stderr).to be == "split\n"
+  end
+
+  it 'has exit_status' do
+    expect(subject.exit_status).to be == 42
+  end
+
+  it 'does not conflate stdout and stderr' do
+    expect(subject.stdout).to eq("banana\n")
+    expect(subject.stderr).to eq("split\n")
+  end
+
+  it 'runs the command lazily' do
+    expect(subject.backend).to receive(:run_command).exactly(0).times
+
+    # Not sending any messages to the subject.
+  end
+
+  it 'does not run the command more than once' do
+    expect(subject.backend).to receive(:run_command).once
+
+    # We can send all these messages, but the command is invoked only once.
+    subject.stdout
+    subject.stderr
+    subject.exit_status
+    subject.return_stdout? 'foo'
+    subject.return_stderr? 'foo'
+    subject.return_exit_status? 0
+  end
+
+  describe '#return_stdout?' do
+    it 'matches against a string, stripping whitespace' do
+      expect(subject.return_stdout? 'banana').to be_true
+      expect(subject.return_stdout? 'pancake').to be_false
+    end
+
+    it 'matches against a regex' do
+      expect(subject.return_stdout? /anan/).to be_true
+      expect(subject.return_stdout? /^anan/).to be_false
+    end
+  end
+
+  describe '#return_stderr?' do
+    it 'matches against a string, stripping whitespace' do
+      expect(subject.return_stderr? 'split').to be_true
+      expect(subject.return_stderr? 'pancake').to be_false
+    end
+
+    it 'matches against a regex' do
+      expect(subject.return_stderr? /pli/).to be_true
+      expect(subject.return_stderr? /^pli/).to be_false
+    end
+  end
+
+  describe '#return_stderr?' do
+    it 'matches against an integer' do
+      expect(subject.return_exit_status? 42).to be_true
+      expect(subject.return_exit_status? 43).to be_false
+    end
+  end
+end


### PR DESCRIPTION
It was previously that if one asserted something about a command's stdout, then
asserted something about the stderr, the 2nd assertion, the one about stderr,
would actually compare to stdout.

Also, each assertion (about the exit status, stdout, stderr), would run the
command each time. Very problematic for commands that are expensive to execute,
or have side effects.

I also added an `exit_status` method to `Command`. The use case is to make assertions other than equality on the exit status, such as against a particular bit being set:

``` ruby
expect(subject.exit_status & 2).to be_zero
```
