### PR TITLE
Fixed bug in RedHat iptables spec helper. In the second operand of the "...

### DIFF
--- a/spec/redhat/iptables_spec.rb
+++ b/spec/redhat/iptables_spec.rb
@@ -13,7 +13,7 @@ end
 
 describe iptables do
   it { should have_rule('-P INPUT ACCEPT').with_table('mangle').with_chain('INPUT') }
-  its(:command) { should eq "iptables -t mangle -S INPUT | grep -- -P\\ INPUT\\ ACCEPT || iptables-save -t mangle | grep -- -P\\ INPUT\\ ACCEPT" }
+  its(:command) { should eq "iptables -t mangle -S INPUT | grep -- -P\\ INPUT\\ ACCEPT || iptables-save -t mangle | | grep -- -A\\ INPUT |  grep -- -P\\ INPUT\\ ACCEPT" }
 end
 
 describe iptables do


### PR DESCRIPTION
...should eq" (iptables-save part) it did not check for the chain's name.

We found that the iptables spec helper did not check the chain's name properly (ie. you could have a port in another chain and it'd still match). This is because the iptables-save part did not check for the chain name.
