### PR TITLE
fix to accept array of strings to exact match of sequence of lines

### DIFF
--- a/lib/serverspec/type/file.rb
+++ b/lib/serverspec/type/file.rb
@@ -16,10 +16,14 @@ module Serverspec
       end
 
       def contain(pattern, from, to)
-        if (from || to).nil?
-          backend.check_file_contain(@name, pattern)
+        if pattern.is_a?(Array)
+          backend.check_file_contain_lines(@name, pattern, from, to)
         else
-          backend.check_file_contain_within(@name, pattern, from, to)
+          if (from || to).nil?
+            backend.check_file_contain(@name, pattern)
+          else
+            backend.check_file_contain_within(@name, pattern, from, to)
+          end
         end
       end
 


### PR DESCRIPTION
This patch provides matcher to check whether the specified file contains specified lines exactly or not.

``` ruby
describe file('/home/mizzy/.ssh/config') do
  ssh_conf_lines = (<<EOL).split(/\n/)
Host some.server.local
    User gosukenator
    IdentityFile ~/.ssh/id_rsa_mizzy
    Port 8022
    StrictHostKeyChecking yes
EOL
  it { should contain ssh_conf_lines }
```

Related with: https://github.com/serverspec/specinfra/pull/85
