### PR TITLE
Evidence collection for each testcase

### DIFF
--- a/lib/serverspec.rb
+++ b/lib/serverspec.rb
@@ -13,32 +13,76 @@ module RSpec
   module Core
     module Formatters
       class BaseTextFormatter < BaseFormatter
-        def dump_failure_info(example)
-          exception = example.execution_result[:exception]
-          exception_class_name = exception_class_name_for(exception)
-          output.puts "#{long_padding}#{failure_color("Failure/Error:")} #{failure_color(read_failed_line(exception, example).strip)}"
-          output.puts "#{long_padding}#{failure_color(exception_class_name)}: #{failure_color(exception.message)}" unless exception_class_name =~ /RSpec/
-          output.puts "#{long_padding}  #{failure_color(example.metadata[:command])}" if example.metadata[:command]
-          output.puts "#{long_padding}  #{failure_color(example.metadata[:stdout])}" if example.metadata[:stdout] != ''
-          exception.message.to_s.split("\n").each { |line| output.puts "#{long_padding}  #{failure_color(line)}" } if exception.message
+        # Follwoing code changes are made to print Evidence ( Real command that is executed at target machine and result of same)
+        # To keep the changes minimal, I have overridden two methods of Class BaseTextFormatter 1. dump_failures 2. dump_failure_info(example)
+        # These functions got overidden only if environment variable is set evidence=true
+        if ENV['evidence'] == "true"
+          def dump_failures
+            output.puts
+            output.puts "Evidence:"
+            examples.each_with_index do |example, index|
+              output.puts
+              pending_fixed?(example) ? dump_pending_fixed(example, index) : dump_failure(example, index)
+            end
+          end
+          def dump_failure_info(example)
+            output.puts "#{long_padding} #{failure_color("Failure:")}" if example.execution_result[:status] == "failed"
+            output.puts "#{long_padding} #{success_color("Success:")}" if example.execution_result[:status] == "passed"
+            output.puts "#{long_padding} #{pending_color("Pending:")}" if example.execution_result[:status] == "pending"
+	    output.puts "#{long_padding}  #{detail_color(example.metadata[:command])}" if example.metadata[:command]
+            output.puts "#{long_padding}  #{detail_color(example.metadata[:stdout])}" if example.metadata[:stdout] != ''
+            output.puts "#{long_padding} #{detail_color("#")} #{detail_color(RSpec::Core::Metadata::relative_path(example.location))}"
+	  end
+        else
+	  def dump_failure_info(example)
+            exception = example.execution_result[:exception]
+            exception_class_name = exception_class_name_for(exception)
+            output.puts "#{long_padding}#{failure_color("Failure/Error:")} #{failure_color(read_failed_line(exception, example).strip)}"
+            output.puts "#{long_padding}#{failure_color(exception_class_name)}: #{failure_color(exception.message)}" unless exception_class_name =~ /RSpec/
+            output.puts "#{long_padding}  #{failure_color(example.metadata[:command])}" if example.metadata[:command]
+            output.puts "#{long_padding}  #{failure_color(example.metadata[:stdout])}" if example.metadata[:stdout] != ''
+            exception.message.to_s.split("\n").each { |line| output.puts "#{long_padding}  #{failure_color(line)}" } if exception.message
 
-          if shared_group = find_shared_group(example)
-            dump_shared_failure_info(shared_group)
+	    if shared_group = find_shared_group(example)
+              dump_shared_failure_info(shared_group)
+            end
           end
         end
       end
       class ProgressFormatter < BaseTextFormatter
-        def dump_failure_info(example)
-          exception = example.execution_result[:exception]
-          exception_class_name = exception_class_name_for(exception)
-          output.puts "#{long_padding}#{failure_color("Failure/Error:")} #{failure_color(read_failed_line(exception, example).strip)}"
-          output.puts "#{long_padding}#{failure_color(exception_class_name)}: #{failure_color(exception.message)}" unless exception_class_name =~ /RSpec/
-          output.puts "#{long_padding}  #{failure_color(example.metadata[:command])}" if example.metadata[:command]
-          output.puts "#{long_padding}  #{failure_color(example.metadata[:stdout])}" if example.metadata[:stdout] != ''
-          exception.message.to_s.split("\n").each { |line| output.puts "#{long_padding}  #{failure_color(line)}" } if exception.message
+	# Follwoing code changes are made to print Evidence ( Real command that is executed at target machine and result of same)
+        # To keep the changes minimal, I have overridden two methods of Class BaseTextFormatter 1. dump_failures 2. dump_failure_info(example)
+        # These functions got overidden only if environment variable is set evidence=true
+	if ENV['evidence'] == "true"
+          def dump_failures
+            output.puts
+            output.puts "Evidence:"
+            examples.each_with_index do |example, index|
+              output.puts
+              pending_fixed?(example) ? dump_pending_fixed(example, index) : dump_failure(example, index)
+	    end
+          end
+          def dump_failure_info(example)
+	    output.puts "#{long_padding} #{failure_color("Failure:")}" if example.execution_result[:status] == "failed"
+	    output.puts "#{long_padding} #{success_color("Success:")}" if example.execution_result[:status] == "passed"
+	    output.puts "#{long_padding} #{pending_color("Pending:")}" if example.execution_result[:status] == "pending"
+	    output.puts "#{long_padding}  #{bold(example.metadata[:command])}" if example.metadata[:command]
+            output.puts "#{long_padding}  #{bold(example.metadata[:stdout])}" if example.metadata[:stdout] != ''
+	    output.puts "#{long_padding} #{detail_color("#")} #{detail_color(RSpec::Core::Metadata::relative_path(example.location))}"
+	  end
+        else
+	  def dump_failure_info(example)
+            exception = example.execution_result[:exception]
+            exception_class_name = exception_class_name_for(exception)
+            output.puts "#{long_padding}#{failure_color("Failure/Error:")} #{failure_color(read_failed_line(exception, example).strip)}"
+            output.puts "#{long_padding}#{failure_color(exception_class_name)}: #{failure_color(exception.message)}" unless exception_class_name =~ /RSpec/
+            output.puts "#{long_padding}  #{failure_color(example.metadata[:command])}" if example.metadata[:command]
+            output.puts "#{long_padding}  #{failure_color(example.metadata[:stdout])}" if example.metadata[:stdout] != ''
+            exception.message.to_s.split("\n").each { |line| output.puts "#{long_padding}  #{failure_color(line)}" } if exception.message
 
-          if shared_group = find_shared_group(example)
-            dump_shared_failure_info(shared_group)
+            if shared_group = find_shared_group(example)
+              dump_shared_failure_info(shared_group)
+            end
           end
         end
       end


### PR DESCRIPTION
This patch adds feature to collect evidences for each testcase depending on users choice

What is Evidence? 
Command that is executed at target machine and result of same.

Changes:
To keep the changes minimal, I have overridden two methods of Class BaseTextFormatter 
1. dump_failures : It prints Evidence: instead of Failure:  and it will invoke base class methods irrespective of success, failure or pending testcases
2. dump_failure_info(example): Now this method will print command executed at backend, its result and backtracing information for each testcase instead of just failure.
- changes are made only in serverspec.rb file 

Note:
These functions will get overridden only if environment variable is set evidence=true

Execution:
After applying this patch 
Execute by following command

```
$ rake spec evidence=true
```

After applying this patch serverspec execution will print the the command executed at backend and its output for each testcase(failed, success)

Please suggest any comments/improvements for this patch.
