### PR TITLE
fix darwin spec

### DIFF
--- a/spec/darwin/port_spec.rb
+++ b/spec/darwin/port_spec.rb
@@ -4,7 +4,7 @@ include SpecInfra::Helper::Darwin
 
 describe port(80) do
   it { should be_listening }
-  its(:command) { should eq 'netstat -tunl | grep -- :80\\ ' }
+  its(:command) { should eq 'lsof -nP -iTCP -sTCP:LISTEN | grep -- :80\\ ' }
 end
 
 describe port('invalid') do

--- a/spec/darwin/service_spec.rb
+++ b/spec/darwin/service_spec.rb
@@ -20,7 +20,7 @@ include SpecInfra::Helper::Darwin
 
 describe service('sshd') do
   it { should be_running }
-  its(:command) { should eq "service sshd status" }
+  its(:command) { should eq "launchctl list | grep sshd | grep -E '^[0-9]+'" }
 end
 
 describe service('invalid-daemon') do


### PR DESCRIPTION
At master b89bbf8e79f060be3e016a9620b9fbf7d0dc0440, I've got following error when I execute `bundle exec rake spec`:

``` log
Failures:

  1) Port "80" command should eq "netstat -tunl | grep -- :80\\ "
     Failure/Error: its(:command) { should eq 'netstat -tunl | grep -- :80\\ ' }


       expected: "netstat -tunl | grep -- :80\\ "
            got: "lsof -nP -iTCP -sTCP:LISTEN | grep -- :80\\ "

       (compared using ==)
     # ./spec/darwin/port_spec.rb:7:in `block (2 levels) in <top (required)>'

  2) Service "sshd" command should eq "service sshd status"
     Failure/Error: its(:command) { should eq "service sshd status" }


       expected: "service sshd status"
            got: "launchctl list | grep sshd | grep -E '^[0-9]+'"

       (compared using ==)
     # ./spec/darwin/service_spec.rb:23:in `block (2 levels) in <top (required)>'
```
