### PR TITLE
Add mtime method to file type

### DIFF
--- a/lib/serverspec/type/file.rb
+++ b/lib/serverspec/type/file.rb
@@ -1,3 +1,5 @@
+require 'date'
+
 module Serverspec
   module Type
     class File < Base
@@ -92,6 +94,11 @@ module Serverspec
 
       def version?(version)
         backend.check_file_version(@name, version)
+      end
+
+      def mtime
+        d = backend.get_file_mtime(@name).stdout.strip
+        DateTime.strptime(d, '%s')
       end
     end
   end


### PR DESCRIPTION
You can test a file modification time like this.

``` ruby
describe file('/var/log/messages') do
  its(:mtime) { should > DateTime.now.prev_day(1) }
end
```
