### PR TITLE
Return mtime as localtime

### DIFF
--- a/lib/serverspec/type/file.rb
+++ b/lib/serverspec/type/file.rb
@@ -98,7 +98,7 @@ module Serverspec
 
       def mtime
         d = backend.get_file_mtime(@name).stdout.strip
-        DateTime.strptime(d, '%s')
+        DateTime.strptime(d, '%s').new_offset(DateTime.now.offset)
       end
     end
   end


### PR DESCRIPTION
I think it is more convenient mtime is time in localtime not in UTC, when comparing to `DateTime.now` (`now` returns in localtime) and see diff in fail message.
