### PR TITLE
Add how to set environment variables by a comment

### DIFF
--- a/lib/serverspec/setup.rb
+++ b/lib/serverspec/setup.rb
@@ -288,6 +288,9 @@ set :ssh_options, options
 <%- end -%>
 <%- end -%>
 
+# Set environment variables
+# set :env, 'LANG' => 'C', 'LC_MESSAGES' => 'C' 
+
 <% if @backend_type == 'WinRM'-%>
 user = <username>
 pass = <password>


### PR DESCRIPTION
You can set environment variables like this.

``` ruby
set :env, 'LANG' => 'C', 'LC_MESSAGES' => 'C' 
```
