### PR TITLE
Add sample how to set path

### DIFF
--- a/lib/serverspec/setup.rb
+++ b/lib/serverspec/setup.rb
@@ -291,6 +291,9 @@ set :ssh_options, options
 # Set environment variables
 # set :env, 'LANG' => 'C', 'LC_MESSAGES' => 'C' 
 
+# Set PATH
+# set :path, '/sbin:/usr/local/sbin:$PATH'
+
 <% if @backend_type == 'WinRM'-%>
 user = <username>
 pass = <password>


### PR DESCRIPTION
In specinfra 1.x, path is added in front of $PATH automatically.

In 2.0, you must include $PATH like this.

``` ruby
set :path, '/sbin:/usr/local/sbin:$PATH'
```
