### PR TITLE
Allow use with rspec 3

### DIFF
--- a/serverspec.gemspec
+++ b/serverspec.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "net-ssh"
-  spec.add_runtime_dependency "rspec", "~> 2.99"
+  spec.add_runtime_dependency "rspec", [">= 2.99", '< 4.0']
   spec.add_runtime_dependency "rspec-its"
   spec.add_runtime_dependency "highline"
   spec.add_runtime_dependency "specinfra", "~> 1.22"


### PR DESCRIPTION
I want to use rspec3, rspec_junit_formatter, test-kitchen & serverspec. Default install of rspec_junit_formatter brings in rspec-core 3, resulting in a conflict with serverspec when running the whole shebang (under busser).

The easiest fix is to allow use of rspec 3.
