### PR TITLE
Fix file_spec of FreeBSD

### DIFF
--- a/spec/freebsd/file_spec.rb
+++ b/spec/freebsd/file_spec.rb
@@ -99,7 +99,7 @@ end
 
 describe file('/etc/pam.d/system-auth') do
   it { should be_linked_to '/etc/pam.d/system-auth-ac' }
-  its(:command) { should eq "stat -c %N /etc/pam.d/system-auth | egrep -e \"-> ./etc/pam.d/system-auth-ac.\"" }
+  its(:command) { should eq "stat -f%Y /etc/pam.d/system-auth | grep --  \"./etc/pam.d/system-auth-ac.\"" }
 end
 
 describe file('dummy-link') do


### PR DESCRIPTION
Use `stat -f` instead of `stat -c`

see also: https://github.com/serverspec/specinfra/pull/166
