### PR TITLE
Adding matchers for the IIS App Pool:

### DIFF
--- a/lib/serverspec/type/iis_app_pool.rb
+++ b/lib/serverspec/type/iis_app_pool.rb
@@ -9,6 +9,30 @@ module Serverspec
         backend.check_iis_app_pool_dotnet(@name, dotnet)
       end
 
+      def has_32bit_enabled?()
+        backend.check_32bit_enabled(@name)
+      end
+
+      def has_idle_timeout?(minutes)
+        backend.check_idle_timeout(@name, minutes)
+      end
+
+      def has_identity_type?(identity_type)
+        backend.check_identity_type(@name, identity_type)
+      end
+
+      def has_periodic_restart?(minutes)
+        backend.check_periodic_restart(@name, minutes)
+      end
+
+      def has_user_profile_enabled?()
+        backend.check_user_profile(@name)
+      end
+
+      def has_username?(username)
+        backend.check_username(@name, username)
+      end
+
       def to_s
         %Q[IIS Application Pool "#{@name}"]
       end


### PR DESCRIPTION
- enabled 32 bit apps on 64 bit machines;
- idle timeouts;
- identity type;
- periodic restart;
- load user profile;
- username;
