### PR TITLE
Remove match_checksum matcher

### DIFF
--- a/lib/serverspec/matcher.rb
+++ b/lib/serverspec/matcher.rb
@@ -4,8 +4,6 @@ require 'serverspec/matcher/contain'
 require 'serverspec/matcher/be_readable'
 require 'serverspec/matcher/be_writable'
 require 'serverspec/matcher/be_executable'
-require 'serverspec/matcher/match_md5checksum'
-require 'serverspec/matcher/match_sha256checksum'
 
 # port
 require 'serverspec/matcher/be_listening'

--- a/lib/serverspec/matcher/match_md5checksum.rb
+++ b/lib/serverspec/matcher/match_md5checksum.rb
@@ -1,5 +1,0 @@
-RSpec::Matchers.define :match_md5checksum do |pattern|
-  match do |file|
-    file.match_md5checksum(pattern)
-  end
-end

--- a/lib/serverspec/matcher/match_sha256checksum.rb
+++ b/lib/serverspec/matcher/match_sha256checksum.rb
@@ -1,5 +1,0 @@
-RSpec::Matchers.define :match_sha256checksum do |pattern|
-  match do |file|
-    file.match_sha256checksum(pattern)
-  end
-end

--- a/lib/serverspec/type/file.rb
+++ b/lib/serverspec/type/file.rb
@@ -77,16 +77,12 @@ module Serverspec
         @runner.check_file_is_immutable(@name)
       end
 
-      def match_checksum(checksum)
-        @runner.check_file_has_checksum(@name, checksum)
+      def md5sum
+        @runner.get_file_md5sum(@name).stdout.strip
       end
 
-      def match_md5checksum(md5sum)
-        @runner.check_file_has_md5checksum(@name, md5sum)
-      end
-
-      def match_sha256checksum(sha256sum)
-        @runner.check_file_has_sha256checksum(@name, sha256sum)
+      def sha256sum
+        @runner.get_file_sha256sum(@name).stdout.strip
       end
 
       def content

--- a/spec/type/base/file_spec.rb
+++ b/spec/type/base/file_spec.rb
@@ -335,19 +335,21 @@ describe file('/etc/invalid-mount') do
 end
 
 describe file('/etc/services') do
-  it { should match_md5checksum '35435ea447c19f0ea5ef971837ab9ced' }
+  let(:stdout) { "35435ea447c19f0ea5ef971837ab9ced\n" }
+  its(:md5sum) { should eq '35435ea447c19f0ea5ef971837ab9ced' }
 end
 
 describe file('invalid-file') do
-  it { should_not match_md5checksum 'INVALIDMD5CHECKSUM' }
+  its(:md5sum) { should_not eq 'INVALIDMD5CHECKSUM' }
 end
 
 describe file('/etc/services') do
-  it { should match_sha256checksum '0c3feee1353a8459f8c7d84885e6bc602ef853751ffdbce3e3b6dfa1d345fc7a' }
+  let(:stdout)  {"0c3feee1353a8459f8c7d84885e6bc602ef853751ffdbce3e3b6dfa1d345fc7a" }
+  its(:sha256sum) { should eq '0c3feee1353a8459f8c7d84885e6bc602ef853751ffdbce3e3b6dfa1d345fc7a' }
 end
 
 describe file('invalid-file') do
-  it { should_not match_sha256checksum 'INVALIDSHA256CHECKSUM' }
+  its(:sha256sum) { should_not eq 'INVALIDSHA256CHECKSUM' }
 end
 
 describe file('/etc/passwd') do

--- a/spec/type/darwin/file_spec.rb
+++ b/spec/type/darwin/file_spec.rb
@@ -15,11 +15,13 @@ describe file('/tmp') do
 end
 
 describe file('/etc/services') do
-  it { should match_md5checksum '35435ea447c19f0ea5ef971837ab9ced' }
+  let(:stdout) { "35435ea447c19f0ea5ef971837ab9ced\n" }
+  its(:md5sum) { should eq '35435ea447c19f0ea5ef971837ab9ced' }
 end
 
 describe file('/etc/services') do
-  it { should match_sha256checksum '0c3feee1353a8459f8c7d84885e6bc602ef853751ffdbce3e3b6dfa1d345fc7a' }
+  let(:stdout)  {"0c3feee1353a8459f8c7d84885e6bc602ef853751ffdbce3e3b6dfa1d345fc7a" }
+  its(:sha256sum) { should eq '0c3feee1353a8459f8c7d84885e6bc602ef853751ffdbce3e3b6dfa1d345fc7a' }
 end
 
 describe file('/etc/pam.d/system-auth') do

--- a/spec/type/openbsd/file_spec.rb
+++ b/spec/type/openbsd/file_spec.rb
@@ -154,17 +154,11 @@ describe file('/etc/invalid-mount') do
 end
 
 describe file('/etc/services') do
-  it { should match_md5checksum '35435ea447c19f0ea5ef971837ab9ced' }
-end
-
-describe file('invalid-file') do
-  it { should_not match_md5checksum 'INVALIDMD5CHECKSUM' }
+  let(:stdout) { "35435ea447c19f0ea5ef971837ab9ced\n" }
+  its(:md5sum) { should eq '35435ea447c19f0ea5ef971837ab9ced' }
 end
 
 describe file('/etc/services') do
-  it { should match_sha256checksum '0c3feee1353a8459f8c7d84885e6bc602ef853751ffdbce3e3b6dfa1d345fc7a' }
-end
-
-describe file('invalid-file') do
-  it { should_not match_sha256checksum 'INVALIDSHA256CHECKSUM' }
+  let(:stdout)  {"0c3feee1353a8459f8c7d84885e6bc602ef853751ffdbce3e3b6dfa1d345fc7a" }
+  its(:sha256sum) { should eq '0c3feee1353a8459f8c7d84885e6bc602ef853751ffdbce3e3b6dfa1d345fc7a' }
 end

--- a/spec/type/solaris10/file_spec.rb
+++ b/spec/type/solaris10/file_spec.rb
@@ -335,19 +335,13 @@ describe file('/etc/invalid-mount') do
 end
 
 describe file('/etc/services') do
-  it { should match_md5checksum '35435ea447c19f0ea5ef971837ab9ced' }
-end
-
-describe file('invalid-file') do
-  it { should_not match_md5checksum 'INVALIDMD5CHECKSUM' }
+  let(:stdout) { "35435ea447c19f0ea5ef971837ab9ced\n" }
+  its(:md5sum) { should eq '35435ea447c19f0ea5ef971837ab9ced' }
 end
 
 describe file('/etc/services') do
-  it { should match_sha256checksum '0c3feee1353a8459f8c7d84885e6bc602ef853751ffdbce3e3b6dfa1d345fc7a' }
-end
-
-describe file('invalid-file') do
-  it { should_not match_sha256checksum 'INVALIDSHA256CHECKSUM' }
+  let(:stdout)  {"0c3feee1353a8459f8c7d84885e6bc602ef853751ffdbce3e3b6dfa1d345fc7a" }
+  its(:md5sum) { should eq '0c3feee1353a8459f8c7d84885e6bc602ef853751ffdbce3e3b6dfa1d345fc7a' }
 end
 
 describe file('/etc/passwd') do


### PR DESCRIPTION
These code are obsoleted.

``` ruby
describe file('/etc/services') do
  it { should match_md5checksum '35435ea447c19f0ea5ef971837ab9ced' }
end

describe file('/etc/services') do
  it { should match_sha256checksum '0c3feee1353a8459f8c7d84885e6bc602ef853751ffdbce3e3b6dfa1d345fc7a' }
end
```

Instead you can write like these.

``` ruby
describe file('/etc/services') do
  its(:md5sum) { should eq '35435ea447c19f0ea5ef971837ab9ced' }
end

describe file('/etc/services') do
  its(:sha256sum) { should eq '0c3feee1353a8459f8c7d84885e6bc602ef853751ffdbce3e3b6dfa1d345fc7a' }
end
```
