### PR TITLE
Remove return_* matcher of command resource

### DIFF
--- a/lib/serverspec/matcher.rb
+++ b/lib/serverspec/matcher.rb
@@ -23,10 +23,6 @@ require 'serverspec/matcher/be_running'
 require 'serverspec/matcher/belong_to_group'
 require 'serverspec/matcher/belong_to_primary_group'
 
-require 'serverspec/matcher/return_exit_status'
-require 'serverspec/matcher/return_stdout'
-require 'serverspec/matcher/return_stderr'
-
 # ipfiter, ipnat, iptables
 require 'serverspec/matcher/have_rule'
 

--- a/lib/serverspec/matcher/return_exit_status.rb
+++ b/lib/serverspec/matcher/return_exit_status.rb
@@ -1,5 +1,0 @@
-RSpec::Matchers.define :return_exit_status do |status|
-  match do |command|
-    command.return_exit_status?(status)
-  end
-end

--- a/lib/serverspec/matcher/return_stderr.rb
+++ b/lib/serverspec/matcher/return_stderr.rb
@@ -1,5 +1,0 @@
-RSpec::Matchers.define :return_stderr do |content|
-  match do |command|
-    command.return_stderr?(content)
-  end
-end

--- a/lib/serverspec/matcher/return_stdout.rb
+++ b/lib/serverspec/matcher/return_stdout.rb
@@ -1,5 +1,0 @@
-RSpec::Matchers.define :return_stdout do |content|
-  match do |command|
-    command.return_stdout?(content)
-  end
-end

--- a/lib/serverspec/type/command.rb
+++ b/lib/serverspec/type/command.rb
@@ -1,26 +1,6 @@
 module Serverspec
   module Type
     class Command < Base
-      def return_stdout?(content)
-        if content.instance_of?(Regexp)
-          stdout =~ content
-        else
-          stdout.strip == content
-        end
-      end
-
-      def return_stderr?(content)
-        if content.instance_of?(Regexp)
-          stderr =~ content
-        else
-          stderr.strip == content
-        end
-      end
-
-      def return_exit_status?(status)
-        exit_status == status
-      end
-
       def stdout
         command_result.stdout
       end

--- a/spec/type/base/command_spec.rb
+++ b/spec/type/base/command_spec.rb
@@ -4,44 +4,44 @@ set :os, :family => 'base'
 
 describe command('cat /etc/resolv.conf') do
   let(:stdout) { "nameserver 127.0.0.1\r\n" }
-  it { should return_stdout("nameserver 127.0.0.1") }
+  its(:stdout) { should match /nameserver 127.0.0.1/ }
 end
 
 describe 'complete matching of stdout' do
   context command('cat /etc/resolv.conf') do
     let(:stdout) { "foocontent-should-be-includedbar\r\n" }
-    it { should_not return_stdout('content-should-be-included') }
+    its(:stdout) { should_not eq 'content-should-be-included' }
   end
 end
 
 describe 'regexp matching of stdout' do
   context command('cat /etc/resolv.conf') do
     let(:stdout) { "nameserver 127.0.0.1\r\n" }
-    it { should return_stdout(/127\.0\.0\.1/) }
+    its(:stdout) { should match /127\.0\.0\.1/ }
   end
 end
 
 describe command('cat /etc/resolv.conf') do
   let(:stderr) { "No such file or directory\r\n" }
-  it { should return_stderr("No such file or directory") }
+  its(:stderr) { should match /No such file or directory/ }
 end
 
 describe 'complete matching of stderr' do
   context command('cat /etc/resolv.conf') do
     let(:stderr) { "No such file or directory\r\n" }
-    it { should_not return_stderr('file') }
+    its(:stdout) { should_not eq 'file' }
   end
 end
 
 describe 'regexp matching of stderr' do
   context command('cat /etc/resolv.conf') do
     let(:stderr) { "No such file or directory\r\n" }
-    it { should return_stderr(/file/) }
+    its(:stderr) { should match /file/ }
   end
 end
 
 describe command('cat /etc/resolv.conf') do
-  it { should return_exit_status 0 }
+  its(:exit_status) { should eq 0 }
 end
 
 describe command('ls -al /') do

--- a/spec/type/windows/command_spec.rb
+++ b/spec/type/windows/command_spec.rb
@@ -5,44 +5,44 @@ set :os, :family => 'windows'
 
 describe command('test_cmd /test/path/file') do
   let(:stdout) { "test output 1.2.3\r\n" }
-  it { should return_stdout("test output 1.2.3") }
+  its(:stdout) { should match /test output 1.2.3/ }
 end
 
 describe 'complete matching of stdout' do
   context command('test_cmd /test/path/file') do
     let(:stdout) { "foocontent-should-be-includedbar\r\n" }
-    it { should_not return_stdout('content-should-be-included') }
+    its(:stdout) { should_not eq 'content-should-be-included' }
   end
 end
 
 describe 'regexp matching of stdout' do
   context command('test_cmd /test/path/file') do
     let(:stdout) { "test output 1.2.3\r\n" }
-    it { should return_stdout(/1\.2\.3/) }
+    its(:stdout) { should match /1\.2\.3/ }
   end
 end
 
 describe command('test_cmd /test/path/file') do
   let(:stderr) { "No such file or directory\r\n" }
-  it { should return_stderr("No such file or directory") }
+  its(:stderr) { should match /No such file or directory/ }
 end
 
 describe 'complete matching of stderr' do
   context command('test_cmd /test/path/file') do
     let(:stderr) { "No such file or directory\r\n" }
-    it { should_not return_stderr('file') }
+    its(:stderr) { should_not eq 'file' }
   end
 end
 
 describe 'regexp matching of stderr' do
   context command('test_cmd /test/path/file') do
     let(:stderr) { "No such file or directory\r\n" }
-    it { should return_stderr(/file/) }
+    its(:stderr) { should match /file/ }
   end
 end
 
 describe command('test_cmd /test/path/file') do
-  it { should return_exit_status 0 }
+  its(:exit_status) { should eq 0 }
 end
 
 describe command('dir "c:\"') do


### PR DESCRIPTION
These are obsoleted.

``` ruby
describe command('foo') do
  it { should return_stdout /stdout/ }
  it { should return_stderr /stderr/ }
  it { should return_exit_status 0 }
end
```

Instead, you can write like these.

``` ruby
describe command('foo') do
  its(:stdout) { should match /stdout/ }
  its(:stderr) { should match /stderr/ }
  its(:exit_status) { should eq 0 }
end
```
