### PR TITLE
Support Vagrant with VMware Fusion

### DIFF
--- a/lib/serverspec/setup.rb
+++ b/lib/serverspec/setup.rb
@@ -219,7 +219,7 @@ end
         list_of_vms = []
         if vagrant_list != ''
           vagrant_list.each_line do |line|
-            if match = /([\w-]+[\s]+)(created|aborted|not created|poweroff|running|saved)[\s](\(virtualbox\)|\(vmware\))/.match(line)
+            if match = /([\w-]+[\s]+)(created|aborted|not created|poweroff|running|saved)[\s](\(virtualbox\)|\(vmware\)|\(vmware_fusion\))/.match(line)
               list_of_vms << match[1].strip!
             end
           end


### PR DESCRIPTION
Use Vagrant with VMWare Fusion, vagrant status output is ...

```
Current machine states:
...
default                   running (vmware_fusion)
...
```
