### PR TITLE
Add support for SELinux modules

### DIFF
--- a/lib/serverspec/helper/type.rb
+++ b/lib/serverspec/helper/type.rb
@@ -5,9 +5,9 @@ module Serverspec
         base cgroup command cron default_gateway file group host
         iis_website iis_app_pool interface ipfilter ipnat iptables
         ip6tables kernel_module linux_kernel_parameter lxc mail_alias
-        package php_config port ppa process routing_table selinux service
-        user yumrepo windows_feature windows_hot_fix windows_registry_key
-        windows_scheduled_task zfs
+        package php_config port ppa process routing_table selinux
+        selinux_module service user yumrepo windows_feature
+        windows_hot_fix windows_registry_key windows_scheduled_task zfs
       )
 
       types.each {|type| require "serverspec/type/#{type}" }

--- a/lib/serverspec/type/selinux_module.rb
+++ b/lib/serverspec/type/selinux_module.rb
@@ -1,0 +1,11 @@
+module Serverspec::Type
+  class SelinuxModule < Base
+    def enabled?
+      @runner.check_selinux_module_is_enabled(@name)
+    end
+
+    def installed?(name, version=nil)
+      @runner.check_selinux_module_is_installed(@name, version)
+    end
+  end
+end

--- a/serverspec.gemspec
+++ b/serverspec.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "rspec", "~> 3.0.0"
+  spec.add_runtime_dependency "rspec", "~> 3.0"
   spec.add_runtime_dependency "rspec-its"
   spec.add_runtime_dependency "specinfra", "~> 2.0"
   spec.add_development_dependency "bundler", "~> 1.3"

--- a/spec/type/linux/selinux_module_spec.rb
+++ b/spec/type/linux/selinux_module_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+set :os, :family => 'linux'
+
+describe selinux_module('bootloader') do
+  it { should be_installed }
+end
+
+describe selinux_module('bootloader') do
+  it { should be_enabled }
+end


### PR DESCRIPTION
# selinux_module

SELinux module resource type.
## be_enabled

In order to test a given SELinux module is enabled(being enforce by the current SELinux policy), you should use the be_enabled matcher.

``` ruby
describe selinux_module('bootloader') do
  it { should be_enabled }
end
```
## be_installed

In order to test a SELinux modules is installed, you should use the be_installed matcher.

``` ruby
describe selinux_module('bootloader') do
  it { should be_installed }
end
```

You can also test a given version of the SELinux module is installed.

``` ruby
describe selinux_module('bootloader') do
  it { should be_installed.with_version('1.13.2') }
end
```
