### PR TITLE
strip stdout and stderr

### DIFF
--- a/lib/serverspec/type/command.rb
+++ b/lib/serverspec/type/command.rb
@@ -1,11 +1,11 @@
 module Serverspec::Type
   class Command < Base
     def stdout
-      command_result.stdout
+      command_result.stdout.strip
     end
 
     def stderr
-      command_result.stderr
+      command_result.stderr.strip
     end
 
     def exit_status


### PR DESCRIPTION
The bump to 2.0 broke several of my tests that used the old syntax:

```
describe command('ls /tmp') do
  it { should return_stdout 'foo' }
  it { should return_stderr 'bar' }
  it { should return_exit_status 0 }
end
```

Converting to the new syntax using:

```
describe command('ls /tmp') do
  its(:stdout) { should eq 'foo' }
  its(:stderr) { should match /bar/ }
  its(:exit_status) { should eq 0 }
end
```

continued to have several broken tests with errors similar to:

```
expected: "datacenters"
got: "datacenters\n"
```

This PR adds a strip to the stderr and stdout which was also present in v1 and fixes my tests. However, I'm not sure if the omission of strip was intentional.
