### PR TITLE
add “source_address” option to “be_reachable” matcher of “host” resource...

### DIFF
--- a/lib/serverspec/matcher/be_reachable.rb
+++ b/lib/serverspec/matcher/be_reachable.rb
@@ -6,9 +6,10 @@ RSpec::Matchers.define :be_reachable  do
       port    = @attr[:port]
       proto   = @attr[:proto]   if @attr[:proto]
       timeout = @attr[:timeout] if @attr[:timeout]
+      source_address = @attr[:source_address] if @attr[:source_address]
     end
 
-    host.reachable?(port, proto, timeout)
+    host.reachable?(port, proto, timeout, source_address)
   end
 
   chain :with do |attr|

--- a/lib/serverspec/type/host.rb
+++ b/lib/serverspec/type/host.rb
@@ -4,8 +4,8 @@ module Serverspec::Type
       @runner.check_host_is_resolvable(@name, type)
     end
 
-    def reachable?(port, proto, timeout)
-      @runner.check_host_is_reachable(@name, port, proto, timeout)
+    def reachable?(port, proto, timeout, source_address)
+      @runner.check_host_is_reachable(@name, port, proto, timeout, source_address)
     end
 
     def ipaddress

--- a/spec/type/base/host_with_source_address_spec.rb
+++ b/spec/type/base/host_with_source_address_spec.rb
@@ -1,0 +1,20 @@
+require 'serverspec'
+
+set :backend, :exec
+set :os, :family => 'base'
+
+describe host('127.0.0.1') do
+  it { should be_reachable }
+end
+
+describe host('127.0.0.1'), 'with source address RFC5735 TEST-NET-1' do
+  it { should_not be_reachable.with(:source_address => '192.0.2.1') }
+end
+
+describe host('127.0.0.1') do
+  it { should be_reachable.with(:proto => "tcp", :port => 25) }
+end
+
+describe host('127.0.0.1'), 'with source address RFC5735 TEST-NET-1' do
+  it { should_not be_reachable.with(:proto => "tcp", :port => 25, :source_address => '192.0.2.1') }
+end


### PR DESCRIPTION
When host is multihome,I want to specify source ip address to test target host’s network reachability.
This change needs 
https://github.com/ymd-mkhk/specinfra/tree/add-source_address-option-to-host-check_is_reachable
.
