### PR TITLE
Add gemspec to highline gem

### DIFF
--- a/serverspec.gemspec
+++ b/serverspec.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "rspec-its"
   spec.add_runtime_dependency "multi_json"
   spec.add_runtime_dependency "specinfra", "~> 2.3"
+  spec.add_runtime_dependency "highline"
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake", "~> 10.1.1"
 end


### PR DESCRIPTION
serverspec-init makes spec/spec_helper.rb. It describe "requires 'highline/line'", however highline don't include Gemfile dependency. 

``` ruby:spec/spec_helper.rb
  7 if ENV['ASK_SUDO_PASSWORD']
  8   begin
  9     require 'highline/import'
 10   rescue LoadError
 11     fail "highline is not available. Try installing it."
 12   end
 13   set :sudo_password, ask("Enter sudo password: ") { |q| q.echo = false }
 14 else
 15   set :sudo_password, ENV['SUDO_PASSWORD']
 16 end
```

```
% cat Gemfile.lock                                                                                                                  [~/repos/serverspec_test]
GEM
  remote: https://rubygems.org/
  specs:
    diff-lcs (1.2.5)
    multi_json (1.10.1)
    net-scp (1.2.1)
      net-ssh (>= 2.6.5)
    net-ssh (2.9.1)
    rspec (3.1.0)
      rspec-core (~> 3.1.0)
      rspec-expectations (~> 3.1.0)
      rspec-mocks (~> 3.1.0)
    rspec-core (3.1.7)
      rspec-support (~> 3.1.0)
    rspec-expectations (3.1.2)
      diff-lcs (>= 1.2.0, < 2.0)
      rspec-support (~> 3.1.0)
    rspec-its (1.0.1)
      rspec-core (>= 2.99.0.beta1)
      rspec-expectations (>= 2.99.0.beta1)
    rspec-mocks (3.1.3)
      rspec-support (~> 3.1.0)
    rspec-support (3.1.2)
    serverspec (2.3.1)
      multi_json
      rspec (~> 3.0)
      rspec-its
      specinfra (~> 2.3)
    specinfra (2.3.2)
      net-scp
      net-ssh

PLATFORMS
  ruby

DEPENDENCIES
  serverspec
```

```
% env ASK_SUDO_PASSWORD=true bundle exec rake                                                                                       [~/repos/serverspec_test]
/Users/mahito/.rbenv/versions/2.1.3/bin/ruby -I/Users/mahito/repos/serverspec_test/vendor/bundle/ruby/2.1.0/gems/rspec-core-3.1.7/lib:/Users/mahito/repos/serverspec_test/vendor/bundle/ruby/2.1.0/gems/rspec-support-3.1.2/lib /Users/mahito/repos/serverspec_test/vendor/bundle/ruby/2.1.0/gems/rspec-core-3.1.7/exe/rspec --pattern spec/serverspec_test/\*_spec.rb
/Users/mahito/repos/serverspec_test/spec/spec_helper.rb:11:in `rescue in <top (required)>': highline is not available. Try installing it. (RuntimeError)
    from /Users/mahito/repos/serverspec_test/spec/spec_helper.rb:8:in `<top (required)>'
    from /Users/mahito/repos/serverspec_test/spec/serverspec_test/sample_spec.rb:1:in `require'
    from /Users/mahito/repos/serverspec_test/spec/serverspec_test/sample_spec.rb:1:in `<top (required)>'
    from /Users/mahito/repos/serverspec_test/vendor/bundle/ruby/2.1.0/gems/rspec-core-3.1.7/lib/rspec/core/configuration.rb:1105:in `load'
    from /Users/mahito/repos/serverspec_test/vendor/bundle/ruby/2.1.0/gems/rspec-core-3.1.7/lib/rspec/core/configuration.rb:1105:in `block in load_spec_files'
    from /Users/mahito/repos/serverspec_test/vendor/bundle/ruby/2.1.0/gems/rspec-core-3.1.7/lib/rspec/core/configuration.rb:1105:in `each'
    from /Users/mahito/repos/serverspec_test/vendor/bundle/ruby/2.1.0/gems/rspec-core-3.1.7/lib/rspec/core/configuration.rb:1105:in `load_spec_files'
    from /Users/mahito/repos/serverspec_test/vendor/bundle/ruby/2.1.0/gems/rspec-core-3.1.7/lib/rspec/core/runner.rb:96:in `setup'
    from /Users/mahito/repos/serverspec_test/vendor/bundle/ruby/2.1.0/gems/rspec-core-3.1.7/lib/rspec/core/runner.rb:84:in `run'
    from /Users/mahito/repos/serverspec_test/vendor/bundle/ruby/2.1.0/gems/rspec-core-3.1.7/lib/rspec/core/runner.rb:69:in `run'
    from /Users/mahito/repos/serverspec_test/vendor/bundle/ruby/2.1.0/gems/rspec-core-3.1.7/lib/rspec/core/runner.rb:37:in `invoke'
    from /Users/mahito/repos/serverspec_test/vendor/bundle/ruby/2.1.0/gems/rspec-core-3.1.7/exe/rspec:4:in `<main>'
/Users/mahito/.rbenv/versions/2.1.3/bin/ruby -I/Users/mahito/repos/serverspec_test/vendor/bundle/ruby/2.1.0/gems/rspec-core-3.1.7/lib:/Users/mahito/repos/serverspec_test/vendor/bundle/ruby/2.1.0/gems/rspec-support-3.1.2/lib /Users/mahito/repos/serverspec_test/vendor/bundle/ruby/2.1.0/gems/rspec-core-3.1.7/exe/rspec --pattern spec/serverspec_test/\*_spec.rb failed
```

I add gemspec to highline. 
