### PR TITLE
Fix Rakefile generation to avoid circular dependency of tasks

### DIFF
--- a/lib/serverspec/setup.rb
+++ b/lib/serverspec/setup.rb
@@ -180,14 +180,15 @@ namespace :spec do
     targets << File.basename(dir)
   end
 
-  task :all     => targets
   task :default => :all
 
-  targets.each do |target|
-    desc "Run serverspec tests to #{target}"
-    RSpec::Core::RakeTask.new(target.to_sym) do |t|
-      ENV['TARGET_HOST'] = target
-      t.pattern = "spec/#{target}/*_spec.rb"
+  task :all do
+    targets.each do |target|
+      desc "Run serverspec tests to #{target}"
+      RSpec::Core::RakeTask.new(target.to_sym) do |t|
+        ENV['TARGET_HOST'] = target
+        t.pattern = "spec/#{target}/*_spec.rb"
+      end
     end
   end
 end


### PR DESCRIPTION
Default generated Rakefile by 'serverspec-init' command causes an error with this procedure.

``` bash
$ bundle exec serverspec-init
 ....
 + Rakefile
 ...
$ bundle exec rake
rake aborted!
Circular dependency detected: TOP => default => spec => spec:all => spec:default => spec:all

Tasks: TOP => default => spec => spec:all => spec:default
(See full trace by running task with --trace)
```

I think we should see sample_spec.rb tests run with failure results instead.
This patch is to avoid this "Circular dependency."

Thanks for the great work of serverspec!
