### PR TITLE
Add 'hostname', 'domain' and 'fqdn' matchers.

### DIFF
--- a/lib/serverspec/type/host.rb
+++ b/lib/serverspec/type/host.rb
@@ -11,5 +11,17 @@ module Serverspec::Type
     def ipaddress
       @runner.get_host_ipaddress(@name).stdout.strip
     end
+
+    def hostname
+      @runner.get_host_name.stdout.strip
+    end
+
+    def domain
+      @runner.get_host_domain.stdout.strip
+    end
+
+    def fqdn
+      @runner.get_host_fqdn.stdout.strip
+    end
   end
 end


### PR DESCRIPTION
Add three matchers to the Host resource type.

its(:hostname) can match the short name
its(:domain) matches the domain portion
its(:fqdn) matches the fully qualified name

Example

```
describe host('localhost') do
  its(:hostname) { should eq 'server' }
  its(:domain) { should eq 'example.com' }
  its(:fqdn) { should eq 'server.example.com' }
end
```
