### PR TITLE
Add 'exists?' matcher for Interface resource type

### DIFF
--- a/lib/serverspec/type/interface.rb
+++ b/lib/serverspec/type/interface.rb
@@ -1,5 +1,9 @@
 module Serverspec::Type
   class Interface < Base
+    def exists?
+      @runner.check_interface_exists(@name)
+    end
+
     def speed
       ret = @runner.get_interface_speed_of(@name)
       val = ret.stdout.strip


### PR DESCRIPTION
Sometimes it's useful to just check that the interface exists, although it
may not have been configured or you may not know what the configuration
(E.g. IP) is.
