### PR TITLE
Exposing serverspec type name

### DIFF
--- a/lib/serverspec/type/base.rb
+++ b/lib/serverspec/type/base.rb
@@ -1,5 +1,8 @@
 module Serverspec::Type
   class Base
+    
+    attr_reader :name
+    
     def initialize(name=nil)
       @name   = name
       @runner = Specinfra::Runner


### PR DESCRIPTION
We have a use case for reading this attribute and I would rather not parse it out of the `to_s` response
