### PR TITLE
Set os in Windows readme examples

### DIFF
--- a/WINDOWS_SUPPORT.md
+++ b/WINDOWS_SUPPORT.md
@@ -10,6 +10,7 @@ For local testing (equivalent to the Exec option in Linux/Unix systems) simply d
 require 'serverspec'
 
 set :backend, :cmd
+set :os, :family => 'windows'
 ```
 
 For remote testing you have to configure Windows Remote Management in order to communicate to the target host:
@@ -19,6 +20,7 @@ require 'serverspec'
 require 'winrm'
 
 set :backend, :winrm
+set :os, :family => 'windows'
 
 user = <username>
 pass = <password>


### PR DESCRIPTION
The readme for Windows instructs users to explicitly set the OS in spec_helper.rb, but the examples given in that document omit that step. This causes problems for those of us who copy and paste the examples. This PR fixes that problem.

The issue was reported at http://stackoverflow.com/questions/26875234/first-should-be-installed-in-test-always-fails-on-windows
