### PR TITLE
Excluding top-level Serverspec DSL inclusion

### DIFF
--- a/lib/serverspec/helper.rb
+++ b/lib/serverspec/helper.rb
@@ -1,6 +1,5 @@
 # Subject type helper
 require 'serverspec/helper/type'
-extend Serverspec::Helper::Type
 class RSpec::Core::ExampleGroup
   extend Serverspec::Helper::Type
   include Serverspec::Helper::Type


### PR DESCRIPTION
At Chef we're working on some logic that leverages RSpec and the Serverspec matchers to query system information after performing a Chef run.  As part of this we're running `require 'serverspec/helper'` to have the Serverspec matchers included into RSpec example groups.

This file also extends the calling class with the Helper types.  This causes issues for us because we define our own DSL which collides with Serverspec - for example, we both provide a `package` method.

In order to mitigate this, can we stop `extending` the top level class with the Serverspec matchers?

RSpec has some extensive logic in https://github.com/rspec/rspec-core/blob/master/lib/rspec/core/dsl.rb to make adding their DSL at the top level optional.  If there is a use case for Serverspec to be included at the top level, could we add some similar logic?  If this is necessary I am happy to talk with the maintainers about the best way to do this and then submit a PR.
