### PR TITLE
Add resource type linux_audit_system

### DIFF
--- a/lib/serverspec/helper/type.rb
+++ b/lib/serverspec/helper/type.rb
@@ -10,7 +10,7 @@ module Serverspec
         windows_feature windows_hot_fix windows_registry_key
         windows_scheduled_task zfs docker_base docker_image
         docker_container x509_certificate x509_private_key
-	linux_audit_system
+        linux_audit_system
       )
 
       types.each {|type| require "serverspec/type/#{type}" }

--- a/lib/serverspec/helper/type.rb
+++ b/lib/serverspec/helper/type.rb
@@ -10,6 +10,7 @@ module Serverspec
         windows_feature windows_hot_fix windows_registry_key
         windows_scheduled_task zfs docker_base docker_image
         docker_container x509_certificate x509_private_key
+	linux_audit_system
       )
 
       types.each {|type| require "serverspec/type/#{type}" }

--- a/lib/serverspec/type/linux_audit_system.rb
+++ b/lib/serverspec/type/linux_audit_system.rb
@@ -15,19 +15,31 @@ module Serverspec::Type
       (!pid.nil? && pid.size > 0 && pid != '0')
     end
 
-    private
-
     def rules
       if @rules_content.nil?
-        @rules_content = @runner.run_command('/sbin/auditctl -l').stdout
-#.split("\n").map(&:chomp)
+        @rules_content = @runner.run_command('/sbin/auditctl -l').stdout || ''
       end
-      @rules_content || []
+      @rules_content
     end
 
+    private
+
     def status_of(part)
-      cmd = "/sbin/auditctl -s | grep \"^#{part}\" | awk '{ print $2 }'"
-	@runner.run_command(cmd).stdout.chomp
+      cmd = "/sbin/auditctl -s"
+      status_str = @runner.run_command(cmd).stdout.chomp
+      status_map = parse_status(status_str)
+      status_map[part] || ''
     end
+
+    def parse_status(status_str)
+      map = nil
+      if status_str =~ /^AUDIT_STATUS/ then
+        map = status_str.split(' ')[1..-1].inject({}) { |res,elem| a = elem.split('='); res.store(a[0],a[1] || ''); res }
+      else
+        map = status_str.split("\n").inject({}) { |res,elem| a = elem.split(' '); res.store(a[0],a[1] || ''); res } 
+      end
+      map
+    end
+
   end
 end

--- a/lib/serverspec/type/linux_audit_system.rb
+++ b/lib/serverspec/type/linux_audit_system.rb
@@ -6,14 +6,6 @@ module Serverspec::Type
       @rules_content = nil
     end
 
-    def has_audit_rule?(rule)
-      if rule.instance_of?(Regexp)
-        return rules.any? { |r| r.match(rule) }
-      else
-        return rules.any? { |r| r == rule }
-      end
-    end
-
     def enabled?
       status_of('enabled') == '1'
     end
@@ -27,9 +19,8 @@ module Serverspec::Type
 
     def rules
       if @rules_content.nil?
-        @rules_content = @runner
-                         .run_command('/sbin/auditctl -l')
-                         .stdout.split("\n").map(&:chomp)
+        @rules_content = @runner.run_command('/sbin/auditctl -l').stdout
+#.split("\n").map(&:chomp)
       end
       @rules_content || []
     end

--- a/lib/serverspec/type/linux_audit_system.rb
+++ b/lib/serverspec/type/linux_audit_system.rb
@@ -1,0 +1,42 @@
+module Serverspec::Type
+  class LinuxAuditSystem < Base
+    def initialize(name=nil)
+      @name = 'linux_audit_system'
+      @runner = Specinfra::Runner
+      @rules_content = nil
+    end
+
+    def has_audit_rule?(rule)
+      if rule.instance_of?(Regexp)
+        return rules.any? { |r| r.match(rule) }
+      else
+        return rules.any? { |r| r == rule }
+      end
+    end
+
+    def enabled?
+      status_of('enabled') == '1'
+    end
+
+    def running?
+      pid = status_of('pid')
+      (!pid.nil? && pid.size > 0 && pid != '0')
+    end
+
+    private
+
+    def rules
+      if @rules_content.nil?
+        @rules_content = @runner
+                         .run_command('/sbin/auditctl -l')
+                         .stdout.split("\n").map(&:chomp)
+      end
+      @rules_content || []
+    end
+
+    def status_of(part)
+      cmd = "/sbin/auditctl -s | grep \"^#{part}\" | awk '{ print $2 }'"
+	@runner.run_command(cmd).stdout.chomp
+    end
+  end
+end

--- a/spec/type/linux/linux_audit_system_spec.rb
+++ b/spec/type/linux/linux_audit_system_spec.rb
@@ -3,32 +3,52 @@ require 'spec_helper'
 set :os, :family => 'linux'
 
 describe linux_audit_system do
-  let(:stdout) { '1' }
+  let(:stdout) { out_auditctl1_1 }
   it { should be_enabled }
 end
 
 describe linux_audit_system do
-  let(:stdout) { '0' }
+  let(:stdout) { out_auditctl1_2 }
   it { should_not be_enabled }
 end
 
 describe linux_audit_system do
-  let(:stdout) { '' }
-  it { should_not be_enabled }
-end
-
-describe linux_audit_system do
-  let(:stdout) { '12345' }
+  let(:stdout) { out_auditctl1_1 }
   it { should be_running }
 end
 
 describe linux_audit_system do
-  let(:stdout) { '0' }
+  let(:stdout) { out_auditctl1_3 }
   it { should_not be_running }
 end
 
 describe linux_audit_system do
-  let(:stdout) { '' }
+  let(:stdout) { out_auditctl1_4 }
+  it { should_not be_running }
+end
+
+describe linux_audit_system do
+  let(:stdout) { out_auditctl2_1 }
+  it { should be_enabled }
+end
+
+describe linux_audit_system do
+  let(:stdout) { out_auditctl2_2 }
+  it { should_not be_enabled }
+end
+
+describe linux_audit_system do
+  let(:stdout) { out_auditctl2_1 }
+  it { should be_running }
+end
+
+describe linux_audit_system do
+  let(:stdout) { out_auditctl2_3 }
+  it { should_not be_running }
+end
+
+describe linux_audit_system do
+  let(:stdout) { out_auditctl2_4 }
   it { should_not be_running }
 end
 
@@ -42,4 +62,78 @@ describe linux_audit_system do
   its(:rules) { should eq 'test' }
   its(:rules) { should match /es/ }
   its(:rules) { should_not match /ab/ }
+end
+
+# variants of auditctl -s output for different versions
+
+def out_auditctl1_1
+  "AUDIT_STATUS: enabled=1 flag=1 pid=881 rate_limit=0 backlog_limit=320 lost=0 backlog=0"
+end
+
+def out_auditctl1_2
+  "AUDIT_STATUS: enabled=0 flag=1 pid=881 rate_limit=0 backlog_limit=320 lost=0 backlog=0"
+end
+
+def out_auditctl1_3
+  "AUDIT_STATUS: enabled=1 flag=1 pid=0 rate_limit=0 backlog_limit=320 lost=0 backlog=0"
+end
+
+def out_auditctl1_4
+  "AUDIT_STATUS: enabled=1 flag=1 pid= rate_limit=0 backlog_limit=320 lost=0 backlog=0"
+end
+
+def out_auditctl2_1
+  <<EOS
+enabled 1
+failure 1
+pid 5939
+rate_limit 0
+backlog_limit 64
+lost 0
+backlog 0
+backlog_wait_time 60000
+loginuid_immutable 0 unlocked
+EOS
+end
+
+def out_auditctl2_2
+  <<EOS
+enabled 0
+failure 1
+pid 5939
+rate_limit 0
+backlog_limit 64
+lost 0
+backlog 0
+backlog_wait_time 60000
+loginuid_immutable 0 unlocked
+EOS
+end
+
+def out_auditctl2_3
+  <<EOS
+enabled 0
+failure 1
+pid 0
+rate_limit 0
+backlog_limit 64
+lost 0
+backlog 0
+backlog_wait_time 60000
+loginuid_immutable 0 unlocked
+EOS
+end
+
+def out_auditctl2_4
+  <<EOS
+enabled 0
+failure 1
+pid
+rate_limit 0
+backlog_limit 64
+lost 0
+backlog 0
+backlog_wait_time 60000
+loginuid_immutable 0 unlocked
+EOS
 end

--- a/spec/type/linux/linux_audit_system_spec.rb
+++ b/spec/type/linux/linux_audit_system_spec.rb
@@ -33,12 +33,13 @@ describe linux_audit_system do
 end
 
 describe linux_audit_system do
-  let(:stdout) { '-a -w /etc/sysconfig -p -k test' }
-  it { should have_audit_rule /-w \/etc\/sysconfig.*-k test/ }
+  let(:stdout) { '-a -w /etc/sysconfig -p wa -k test' }
+  its(:rules) { should match %r!-w /etc/sysconfig.*-k test! }
 end
 
 describe linux_audit_system do
   let(:stdout) { 'test' }
-  it { should have_audit_rule /es/ }
-  it { should_not have_audit_rule /ab/ }
+  its(:rules) { should eq 'test' }
+  its(:rules) { should match /es/ }
+  its(:rules) { should_not match /ab/ }
 end

--- a/spec/type/linux/linux_audit_system_spec.rb
+++ b/spec/type/linux/linux_audit_system_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+set :os, :family => 'linux'
+
+describe linux_audit_system do
+  let(:stdout) { '1' }
+  it { should be_enabled }
+end
+
+describe linux_audit_system do
+  let(:stdout) { '0' }
+  it { should_not be_enabled }
+end
+
+describe linux_audit_system do
+  let(:stdout) { '' }
+  it { should_not be_enabled }
+end
+
+describe linux_audit_system do
+  let(:stdout) { '12345' }
+  it { should be_running }
+end
+
+describe linux_audit_system do
+  let(:stdout) { '0' }
+  it { should_not be_running }
+end
+
+describe linux_audit_system do
+  let(:stdout) { '' }
+  it { should_not be_running }
+end
+
+describe linux_audit_system do
+  let(:stdout) { '-a -w /etc/sysconfig -p -k test' }
+  it { should have_audit_rule /-w \/etc\/sysconfig.*-k test/ }
+end
+
+describe linux_audit_system do
+  let(:stdout) { 'test' }
+  it { should have_audit_rule /es/ }
+  it { should_not have_audit_rule /ab/ }
+end


### PR DESCRIPTION
Allow checking the configuration of linux audit system via `/sbin/auditctl`. Suitable for server hardening.

## be_running

To make sure that the audit system is running.

```
describe linux_audit_system do
  it { should be_running }
end
```

## be_enabled

To make sure that the audit system is enabled (mode '1').

```
describe linux_audit_system do
  it { should be_enabled }
end
```

## have_audit_rule

To check that auditd has a given auditing rule. Argument can be a string for equality comparison or a regular expression.

```
describe linux_audit_system do
  it { should have_audit_rule '-w /etc/audit/ -p wa' }
  it { should have_audit_rule '-w /var/lib/ -p wa' }
  it { should have_audit_rule /\/var\/lib\// }
  it { should_not have_audit_rule /\/var\/log\// }
end
```

