### PR TITLE
docker_container: Restarting != running

### DIFF
--- a/lib/serverspec/type/docker_container.rb
+++ b/lib/serverspec/type/docker_container.rb
@@ -1,7 +1,7 @@
 module Serverspec::Type
   class DockerContainer < DockerBase
     def running?
-      inspection['State']['Running']
+      inspection['State']['Running'] && !inspection['State']['Restarting']
     end
 
     def has_volume?(container_path, host_path)

--- a/serverspec.gemspec
+++ b/serverspec.gemspec
@@ -23,5 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "multi_json"
   spec.add_runtime_dependency "specinfra", "~> 2.43"
   spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency("json", "~> 1.8") if RUBY_VERSION < "1.9"
   spec.add_development_dependency "rake", "~> 10.1.1"
 end

--- a/spec/type/linux/docker_container_spec.rb
+++ b/spec/type/linux/docker_container_spec.rb
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 require 'spec_helper'
+require 'json'
 
 property[:os] = nil
 set :os, {:family => 'linux'}
@@ -14,6 +15,16 @@ describe docker_container('c1') do
   it { should have_volume('/tmp', '/data') }
   its(:inspection) { should include 'Driver' => 'aufs' }
   its(['Config.Cmd']) { should include '/bin/sh' }
+end
+
+describe docker_container('restarting') do
+  let(:stdout) do
+    attrs = JSON.parse(inspect_container)
+    attrs.first['State']['Restarting'] = true
+    attrs.to_json
+  end
+
+  it { should_not be_running }
 end
 
 def inspect_container


### PR DESCRIPTION
`DockerContainer#running?` was returning `true` regardless of whether or not a container was restarting. A restarting container is not actually running (and probably indicates an issue). This fixes the `#running?` check to take restarting into account.