### PR TITLE
Add access to Docker config arrays.

### DIFF
--- a/lib/serverspec/type/docker_base.rb
+++ b/lib/serverspec/type/docker_base.rb
@@ -9,7 +9,8 @@ module Serverspec::Type
     def [](key)
       value = inspection
       key.split('.').each do |k|
-        value = value[k]
+        is_index = k.start_with?('[') && k.end_with?(']')
+        value = value[is_index ? k.to_i : k]
       end
       value
     end

--- a/spec/type/linux/docker_container_spec.rb
+++ b/spec/type/linux/docker_container_spec.rb
@@ -15,6 +15,7 @@ describe docker_container('c1') do
   it { should have_volume('/tmp', '/data') }
   its(:inspection) { should include 'Driver' => 'aufs' }
   its(['Config.Cmd']) { should include '/bin/sh' }
+  its(['HostConfig.PortBindings.80.[0].HostPort']) { should eq '8080' }
 end
 
 describe docker_container('restarting') do
@@ -73,7 +74,14 @@ def inspect_container
         "Links": null,
         "LxcConf": [],
         "NetworkMode": "bridge",
-        "PortBindings": {},
+        "PortBindings": {
+            "80": [
+                {
+                    "HostIp": "",
+                    "HostPort": "8080"
+                }
+            ]
+        },
         "Privileged": false,
         "PublishAllPorts": false,
         "VolumesFrom": null


### PR DESCRIPTION
Support accessing arrays from the "docker inspect" output via normal index access. 

Use case is for accessing specific port bindings as the test shows. The ordering for this use case (and most like it, probably) isn't guaranteed though, so open to suggestions for other ways to solve?

BTW, without this, trying `'HostConfig.PortBindings.80.[0].HostPort'` would throw when trying to get `value['0']` with this: `TypeError: no implicit conversion of String into Integer`.