### PR TITLE
set dependencies to purge cache when updated appveyor.yml.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,14 +21,14 @@ matrix:
 clone_depth: 5
 
 cache:
-  - C:\Ruby193\lib\ruby\gems\1.9.1
-  - C:\Ruby193\bin
-  - C:\Ruby200\lib\ruby\gems\2.0.0
-  - C:\Ruby200\bin
-  - C:\Ruby21\lib\ruby\gems\2.1.0
-  - C:\Ruby21\bin
-  - C:\Ruby22\lib\ruby\gems\2.2.0
-  - C:\Ruby22\bin
+  - C:\Ruby193\lib\ruby\gems\1.9.1 -> appveyor.yml
+  - C:\Ruby193\bin                 -> appveyor.yml
+  - C:\Ruby200\lib\ruby\gems\2.0.0 -> appveyor.yml
+  - C:\Ruby200\bin                 -> appveyor.yml
+  - C:\Ruby21\lib\ruby\gems\2.1.0  -> appveyor.yml
+  - C:\Ruby21\bin                  -> appveyor.yml
+  - C:\Ruby22\lib\ruby\gems\2.2.0  -> appveyor.yml
+  - C:\Ruby22\bin                  -> appveyor.yml
 
 install:
   - git submodule update --init --recursive


### PR DESCRIPTION
Appveyor occasionally fails due to old cache.

For example.

- updates ruby version on appveyor.
    - uses old version gems.  => https://ci.appveyor.com/project/serverspec-windows-integration-test/specinfra/build/job/rhfaur31yhuc0iay

This PR cleans up cache once.