### PR TITLE
Docker 1.8 support

### DIFF
--- a/lib/serverspec/type/docker_container.rb
+++ b/lib/serverspec/type/docker_container.rb
@@ -20,7 +20,6 @@ module Serverspec::Type
       }
     end
 
-    private
     def check_volume_pre_1_8(container_path, host_path)
       inspection['Volumes'][container_path] == host_path
     end

--- a/lib/serverspec/type/docker_container.rb
+++ b/lib/serverspec/type/docker_container.rb
@@ -5,6 +5,23 @@ module Serverspec::Type
     end
 
     def has_volume?(container_path, host_path)
+      if (inspection['Mounts'])
+        check_volume(container_path, host_path)
+      else
+        check_volume_pre_1_8(container_path, host_path)
+      end
+    end
+
+    private
+    def check_volume(container_path, host_path)
+      inspection['Mounts'].find {|mount|
+        mount['Destination'] == container_path &&
+        mount['Source'] == host_path
+      }
+    end
+
+    private
+    def check_volume_pre_1_8(container_path, host_path)
       inspection['Volumes'][container_path] == host_path
     end
   end

--- a/spec/type/linux/docker_container_pre_1_8_spec.rb
+++ b/spec/type/linux/docker_container_pre_1_8_spec.rb
@@ -9,7 +9,7 @@ describe docker_container('c1') do
   it { should exist }
 end
 
-describe docker_container('c1') do
+describe docker_container('c1 pre 1.8') do
   let(:stdout) { inspect_container }
   it { should be_running }
   it { should have_volume('/tmp', '/data') }
@@ -19,7 +19,7 @@ describe docker_container('c1') do
   its(['HostConfig.PortBindings.80.[0].HostPort']) { should eq '8080' }
 end
 
-describe docker_container('restarting') do
+describe docker_container('restarting pre 1.8') do
   let(:stdout) do
     attrs = JSON.parse(inspect_container)
     attrs.first['State']['Restarting'] = true
@@ -112,14 +112,12 @@ def inspect_container
         "Running": true,
         "StartedAt": "2014-09-26T15:08:37.737780273Z"
     },
-    "Mounts": [
-        {
-            "Source": "/data",
-            "Destination": "/tmp",
-            "Mode": "",
-            "RW": true
-        }
-    ]
+    "Volumes": {
+        "/tmp": "/data"
+    },
+    "VolumesRW": {
+        "/tmp": true
+    }
 }
 ]
 EOS

--- a/spec/type/linux/docker_container_spec.rb
+++ b/spec/type/linux/docker_container_spec.rb
@@ -13,6 +13,7 @@ describe docker_container('c1') do
   let(:stdout) { inspect_container }
   it { should be_running }
   it { should have_volume('/tmp', '/data') }
+  it { should_not have_volume('/tmp', '/data-bad') }
   its(:inspection) { should include 'Driver' => 'aufs' }
   its(['Config.Cmd']) { should include '/bin/sh' }
   its(['HostConfig.PortBindings.80.[0].HostPort']) { should eq '8080' }


### PR DESCRIPTION
Docker 1.8 changed the format of the json response of `docker inspect` starting in 1.8, [specifically relating to volumes](http://www.adelton.com/docs/docker/docker-inspect-volumes-mounts).

Doing a check for the new node and asserting against that for the `has_volume?` matcher, falling back to pre 1.8 if it's not found.