### PR TITLE
Update the exception monkeypatch to work with RSpec 3.4.0

### DIFF
--- a/lib/serverspec.rb
+++ b/lib/serverspec.rb
@@ -43,7 +43,12 @@ if defined?(RSpec::Core::Formatters::ExceptionPresenter)
         begin
           lines = []
           lines << "On host `#{host}'" if host
-          lines << failure_slash_error_line unless (description == failure_slash_error_line)
+          error_lines = if defined?(failure_slash_error_lines)
+            failure_slash_error_lines
+          else
+            [failure_slash_error_line]
+          end
+          lines += error_lines if error_lines unless (description == error_lines.join(''))
           lines << "#{exception_class_name}:" unless exception_class_name =~ /RSpec/
           encoded_string(exception.message.to_s).split("\n").each do |line|
             lines << "  #{line}"


### PR DESCRIPTION
https://github.com/rspec/rspec-core/commit/438512e5c64cbc464a018a5e3b710f30454c8e11 was part of the 3.4 release today, and reworked that method to return an array (and also renamed it).

Untested, just trying to get something up for the record.