### PR TITLE
curl resource type

### DIFF
--- a/lib/serverspec/helper/type.rb
+++ b/lib/serverspec/helper/type.rb
@@ -2,7 +2,7 @@ module Serverspec
   module Helper
     module Type
       types = %w(
-        base bridge bond cgroup command cron default_gateway file fstab
+        base bridge bond cgroup command cron curl default_gateway file fstab
         group host iis_website iis_app_pool interface ipfilter ipnat
         iptables ip6tables kernel_module linux_kernel_parameter lxc
         mail_alias mysql_config package php_config port ppa process

--- a/lib/serverspec/type/curl.rb
+++ b/lib/serverspec/type/curl.rb
@@ -1,0 +1,32 @@
+require 'net/http'
+
+module Serverspec
+  module Type
+    class Curl < Base
+      def initialize(endpt)
+        @endpoint = %r{^https?://}.match(endpt) ? endpt : "http://#{endpt}"
+      end
+
+      def ok?
+        begin
+          uri = URI(@endpoint)
+          response = Net::HTTP.get_response(uri)
+        rescue Exception => e
+          puts e.message
+          return false
+        end
+        response.code == '200'
+      end
+
+      def to_s
+        'Curl'
+      end
+    end
+
+    def curl(endpoint)
+      Curl.new(endpoint)
+    end
+  end
+end
+
+include Serverspec::Type


### PR DESCRIPTION
This is resource type that turns the following  example

it 'ensures website is up' do
  expect((command 'wget -o /dev/null -T1 localhost/somewhere).exit_status).to equal 0
end

into

it 'ensures website is up' do
  expect(curl 'localhost/somewhere').to be_ok
end



