### PR TITLE
Added mode, owner_user, and owner_group methods to file

### DIFF
--- a/lib/serverspec/type/file.rb
+++ b/lib/serverspec/type/file.rb
@@ -113,6 +113,10 @@ module Serverspec::Type
       @content
     end
 
+    def group
+      @runner.get_file_owner_group(@name).stdout.strip
+    end
+
     def version?(version)
       @runner.check_file_has_version(@name, version)
     end
@@ -121,9 +125,17 @@ module Serverspec::Type
       @runner.get_file_link_target(@name).stdout.strip
     end
 
+    def mode
+      @runner.get_file_mode(@name).stdout.strip
+    end
+
     def mtime
       d = @runner.get_file_mtime(@name).stdout.strip
       DateTime.strptime(d, '%s').new_offset(DateTime.now.offset)
+    end
+
+    def owner
+      @runner.get_file_owner_user(@name).stdout.strip
     end
 
     def size

--- a/spec/type/base/file_spec.rb
+++ b/spec/type/base/file_spec.rb
@@ -320,6 +320,11 @@ describe file('invalid-file') do
 end
 
 describe file('/etc/passwd') do
+  let(:stdout) { "root\r\n" }
+  its(:group) { should eq 'root' }
+end
+
+describe file('/etc/passwd') do
   let(:stdout) {<<EOF
 root:x:0:0:root:/root:/bin/bash
 bin:x:1:1:bin:/bin:/sbin/nologin
@@ -343,8 +348,18 @@ describe file('/etc/pam.d/system-auth') do
 end
 
 describe file('/etc/passwd') do
+  let(:stdout) { "644\r\n" }
+  its(:mode) { should eq '644' }
+end
+
+describe file('/etc/passwd') do
   let(:stdout) { Time.now.to_i.to_s }
   its(:mtime) { should > DateTime.now - 1 }
+end
+
+describe file('/etc/passwd') do
+  let(:stdout) { "root\r\n" }
+  its(:owner) { should eq 'root' }
 end
 
 describe file('/etc/passwod') do


### PR DESCRIPTION
When writing tests, I was getting frustrated at the poor feedback I was getting for mode, user, and group. For example, in the error below, there is no information about what the current mode is:

```
expected `File "/etc/ssl/private/twolfson.com.key".mode?("300")` to return true, got false
```

I saw that we have an `mtime` method and while I don't know its motivations (kind of hard with no GitHub issues or related PR in the blame =/). However, I gave a shot at adding in `mode,` owner_user`, and `owner_group`. In this PR:

- Added `mode`, `owner_user`, and `owner_group` methods to file
- Added tests