### PR TITLE
mysql_config was failling on new mariadb server

### DIFF
--- a/lib/serverspec/type/mysql_config.rb
+++ b/lib/serverspec/type/mysql_config.rb
@@ -1,8 +1,8 @@
 module Serverspec::Type
   class MysqlConfig < Base
     def value
-      ret = @runner.run_command("mysqld --verbose --help 2> /dev/null | grep '^#{@name}'")
-      val = ret.stdout.match(/#{@name}\s+(.+)$/)[1]
+      ret = @runner.run_command("mysqladmin variables 2> /dev/null | tr -d '|' | grep '#{@name}'")
+      val = ret.stdout.match(/#{@name}\s+(.+)$/)[1].strip
       val = val.to_i if val.match(/^\d+$/)
       val
     end


### PR DESCRIPTION
On centos7 tested.
a. Mysqld command is not in default location under PATH under centos7, 
b. Mariadb recommonds to use mysqladmin command to search for variables