### PR TITLE
Added link_target to file

### DIFF
--- a/lib/serverspec/type/file.rb
+++ b/lib/serverspec/type/file.rb
@@ -117,6 +117,10 @@ module Serverspec::Type
       @runner.check_file_has_version(@name, version)
     end
 
+    def link_target
+      @runner.get_file_link_target(@name).stdout.strip
+    end
+
     def mtime
       d = @runner.get_file_mtime(@name).stdout.strip
       DateTime.strptime(d, '%s').new_offset(DateTime.now.offset)

--- a/spec/type/base/file_spec.rb
+++ b/spec/type/base/file_spec.rb
@@ -337,6 +337,11 @@ EOF
   its(:content) { should match /root:x:0:0/ }
 end
 
+describe file('/etc/pam.d/system-auth') do
+  let(:stdout) { "/etc/pam.dsystem-auth-ac\r\n" }
+  its(:link_target) { should eq '/etc/pam.dsystem-auth-ac' }
+end
+
 describe file('/etc/passwd') do
   let(:stdout) { Time.now.to_i.to_s }
   its(:mtime) { should > DateTime.now - 1 }


### PR DESCRIPTION
As in #544, I prefer to write my tests without matchers unless necessary to get better debugging info (e.g. "/etc/abc" != "/etc/xyz"). I ran into another scenario where we are missing a nice property, `link_target`.

In this PR:

- Added `link_target` method to file
- Added test

**Notes:**

For reference, Chef's naming is `to` and Puppet's naming is `target`. I used `link_target` since it seemed strange to have `target` imply we are referring to a symlink and `to` was too vague. However, I am willing to change `link_target` to whatever you prefer.

https://docs.chef.io/resource_link.html

https://docs.puppetlabs.com/references/latest/type.html#file