### PR TITLE
Add php_ini type and have_config matcher.

### DIFF
--- a/lib/serverspec/type/base.rb
+++ b/lib/serverspec/type/base.rb
@@ -3,9 +3,10 @@ module Serverspec::Type
     
     attr_reader :name
     
-    def initialize(name=nil)
-      @name   = name
-      @runner = Specinfra::Runner
+    def initialize(name=nil, options = {})
+      @name    = name
+      @options = options
+      @runner  = Specinfra::Runner
     end
 
     def to_s

--- a/lib/serverspec/type/php_config.rb
+++ b/lib/serverspec/type/php_config.rb
@@ -1,7 +1,9 @@
 module Serverspec::Type
   class PhpConfig < Base
     def value
-      ret = @runner.run_command("php -r 'echo get_cfg_var( \"#{@name}\" );'")
+      extra = '';
+      extra = extra + "-c #{@options[:ini]}" if @options.has_key?(:ini)
+      ret = @runner.run_command("php #{extra} -r 'echo get_cfg_var( \"#{@name}\" );'")
       val = ret.stdout
       val = val.to_i if val.match(/^\d+$/)
       val

--- a/spec/type/base/php_config_spec.rb
+++ b/spec/type/base/php_config_spec.rb
@@ -31,3 +31,7 @@ describe php_config('mbstring.http_output_conv_mimetypes') do
   let(:stdout) { 'application' }
   its(:value) { should_not match /html/ }
 end
+describe php_config('default_mimetype', :ini => '/etc/php5/php.ini') do
+  let(:stdout) { 'text/html' }
+  its(:value) { should eq 'text/html' }
+end


### PR DESCRIPTION
Hi Mizzy,

First thanks for all your work on this tool. 

Here my situation, I was trying to write some specifications for an Ubuntu server with some Nginx PHP-FPM stack. As you may know Ubuntu has specific php.ini for CLI, apache2, FPM. Sadly, you can't specify the php.ini when using php_config type so I have created my own type called php_ini.

Let me know what do you think about it, any feedback is welcome!

Thanks!