### PR TITLE
Added mtu option to interface resouce type

### DIFF
--- a/lib/serverspec/type/interface.rb
+++ b/lib/serverspec/type/interface.rb
@@ -6,9 +6,12 @@ module Serverspec::Type
 
     def speed
       ret = @runner.get_interface_speed_of(@name)
-      val = ret.stdout.strip
-      val = val.to_i if val.match(/^\d+$/)
-      val
+      val_to_integer(ret)
+    end
+
+    def mtu
+      ret = @runner.get_interface_mtu_of(@name)
+      val_to_integer(ret)
     end
 
     def has_ipv4_address?(ip_address)
@@ -23,5 +26,14 @@ module Serverspec::Type
       ret = @runner.get_interface_link_state(@name)
       ret.stdout.strip == 'up'
     end
+
+    private
+
+    def val_to_integer(ret)
+      val = ret.stdout.strip
+      val = val.to_i if val.match(/^\d+$/)
+      val
+    end
+
   end
 end

--- a/spec/type/linux/interface_spec.rb
+++ b/spec/type/linux/interface_spec.rb
@@ -8,6 +8,11 @@ describe interface('eth0') do
 end
 
 describe interface('eth0') do
+  let(:stdout) { '1500' }
+  its(:mtu) { should eq 1500 }
+end
+
+describe interface('eth0') do
   it { should have_ipv4_address('192.168.10.10') }
 end
 
@@ -28,3 +33,9 @@ describe interface('invalid-interface') do
   let(:stdout) { '1000' }
   its(:speed) { should_not eq 100 }
 end
+
+describe interface('invalid-interface') do
+  let(:stdout) { '9001' }
+  its(:mtu) { should_not eq 1500 }
+end
+


### PR DESCRIPTION
Hi, mizzy san

I added `mtu` option to interface resouce type becase I wanted to test NIC's MTU value.
I want to write MTU check as the following.

```
require 'spec_helper'

describe interface('eth0') do
  its(:speed) { should eq 1000 }
  its(:mtu) { should eq 1500 }
end
```

and I aggregated the common processing of mtu and speed method to `val_to_integer` method.

Please confirm it.
Thank you.

Yohei