### PR TITLE
Removed piping results to shasum to avoid test passing incorrectly

### DIFF
--- a/lib/serverspec/type/x509_private_key.rb
+++ b/lib/serverspec/type/x509_private_key.rb
@@ -12,9 +12,8 @@ module Serverspec::Type
     end
 
     def has_matching_certificate?(cert_file)
-      mac_op = "openssl sha -sha512"
-      h1 = @runner.run_command("openssl x509 -noout -modulus -in #{cert_file} | #{mac_op}")
-      h2 = @runner.run_command("openssl rsa -noout -modulus -in #{name} | #{mac_op}")
+      h1 = @runner.run_command("openssl x509 -noout -modulus -in #{cert_file}")
+      h2 = @runner.run_command("openssl rsa -noout -modulus -in #{name}")
       (h1.stdout == h2.stdout) && (h1.exit_status == 0) && (h2.exit_status == 0)
     end
   end


### PR DESCRIPTION
I understand that this was supposed to be some sort of optimisation, but because `h1.exit_status` and `h2.exit_status` will always inherit the exit code of the latter `openssl sha -sha512`, the test would pass if both: the certificate and the key were invalid or the files were non-existent.

For example the following check always passed:

    describe x509_private_key('/some/non-existent/key/file') do
        it { should have_matching_certificate('/etc/passwd') }
    end

Removing the pipe solves the problem, but I guess the correct way for such cases should be decided for the whole project. For example to make  `run_command` to behave like bash with `'set -o pipefail'`.