### PR TITLE
Remove call to failure_slash_error_line.

### DIFF
--- a/lib/serverspec.rb
+++ b/lib/serverspec.rb
@@ -43,12 +43,9 @@ if defined?(RSpec::Core::Formatters::ExceptionPresenter)
         begin
           lines = []
           lines << "On host `#{host}'" if host
-          error_lines = if defined?(failure_slash_error_lines)
-            failure_slash_error_lines
-          else
-            [failure_slash_error_line]
-          end
-          lines += error_lines if error_lines unless (description == error_lines.join(''))
+          error_lines = []
+          error_lines = failure_slash_error_lines if defined?(failure_slash_error_lines)
+          lines += error_lines unless (description == error_lines.join(''))
           lines << "#{exception_class_name}:" unless exception_class_name =~ /RSpec/
           encoded_string(exception.message.to_s).split("\n").each do |line|
             lines << "  #{line}"


### PR DESCRIPTION
Comment from the commit:

> failure_slash_error_line is currently not defined in rspec-core (ref https://github.com/rspec/rspec-core/blob/master/lib/rspec/core/formatters/exception_presenter.rb).
> 
> This fix addresses a current breakage, but since the code currently monkeypatches private methods, it may still be brittle.

I was trying to get InSpec working to test my Chef cookbooks, and had to upgrade serverspec in order to meet the net-ssh dependency constraints.  When I did so, running kitchen verify gave error

```
>>>>>> ------Exception-------
>>>>>> Class: Kitchen::ActionFailed
>>>>>> Message: Failed to complete #verify action: [undefined local variable or method `failure_slash_error_line' for #<RSpec::Core::Formatters::ExceptionPresenter:0x007fbdfa564248>]
>>>>>> ----------------------
>>>>>> Please see .kitchen/logs/kitchen.log for more details
>>>>>> Also try running `kitchen diagnose --all` for configuration
```

Searching gave this tweet: https://twitter.com/kantrn/status/664913752832126976

I have tried this locally on my cookbook development and the error is resolved.  I don't know how to run the rspec tests for serverspec itself, though, so this PR is effectively untested.
