### PR TITLE
Handle calls to failure_slash_error_line[s].

### DIFF
--- a/lib/serverspec.rb
+++ b/lib/serverspec.rb
@@ -43,12 +43,10 @@ if defined?(RSpec::Core::Formatters::ExceptionPresenter)
         begin
           lines = []
           lines << "On host `#{host}'" if host
-          error_lines = if defined?(failure_slash_error_lines)
-            failure_slash_error_lines
-          else
-            [failure_slash_error_line]
-          end
-          lines += error_lines if error_lines unless (description == error_lines.join(''))
+          error_lines = []
+          error_lines = [failure_slash_error_line] if defined?(failure_slash_error_line)
+          error_lines = failure_slash_error_lines if defined?(failure_slash_error_lines)
+          lines += error_lines unless (description == error_lines.join(''))
           lines << "#{exception_class_name}:" unless exception_class_name =~ /RSpec/
           encoded_string(exception.message.to_s).split("\n").each do |line|
             lines << "  #{line}"


### PR DESCRIPTION
This PR replaces https://github.com/mizzy/serverspec/pull/553

failure_slash_error_line is currently not defined in rspec-core
(ref https://github.com/rspec/rspec-core/blob/master/lib/rspec/core/formatters/exception_presenter.rb).
This change uses it or failure_slash_error_lines if either of those are defined.

Ref this tweet: https://twitter.com/kantrn/status/664913752832126976

I have tried this locally on my cookbook development and the error is resolved. I don't know how to run the rspec tests for serverspec itself, though, so this PR is effectively untested.