### PR TITLE
Adding with_name matcher to be_monitored_by

### DIFF
--- a/lib/serverspec/matcher.rb
+++ b/lib/serverspec/matcher.rb
@@ -22,6 +22,7 @@ require 'serverspec/matcher/be_permissive'
 # service
 require 'serverspec/matcher/be_enabled'
 require 'serverspec/matcher/be_running'
+require 'serverspec/matcher/be_monitored_by'
 
 # user
 require 'serverspec/matcher/belong_to_group'

--- a/lib/serverspec/matcher/be_monitored_by.rb
+++ b/lib/serverspec/matcher/be_monitored_by.rb
@@ -1,0 +1,17 @@
+RSpec::Matchers.define :be_monitored_by do |monitor|
+  match do |service|
+    service.monitored_by?(monitor, @monitor_name)
+  end
+  description do 
+    if @monitor_name
+      "be monitored by #{monitor} with name #{@monitor_name}"
+    else 
+      "be monitored by #{monitor}" 
+    end 
+  end 
+
+  chain :with_name do |name|
+    @monitor_name = (name ? name : nil)
+  end
+
+end

--- a/lib/serverspec/type/service.rb
+++ b/lib/serverspec/type/service.rb
@@ -25,9 +25,11 @@ module Serverspec::Type
       end
     end
 
-    def monitored_by?(monitor)
+    def monitored_by?(monitor, monitor_name)
       check_method = "check_service_is_monitored_by_#{monitor}".to_sym
-      res = @runner.send(check_method, @name)
+      # use the with_name value if set instead of the service name
+      monitor_name = (monitor_name ? monitor_name : @name)
+      res = @runner.send(check_method, monitor_name)
     end
 
     def has_property?(property)

--- a/spec/type/base/service_spec.rb
+++ b/spec/type/base/service_spec.rb
@@ -36,6 +36,11 @@ describe service('sshd') do
   it { should be_monitored_by(:monit) }
 end
 
+describe service('tinc') do
+  let(:stdout) { "Process 'tinc-myvpn'\r\n  status running\r\n  monitoring status  monitored" }
+  it { should be_monitored_by(:monit).with_name('tinc-myvpn') }
+end
+
 describe service('unicorn') do
   it { should be_monitored_by(:god) }
 end


### PR DESCRIPTION
Summary:
  Added mainly for tinc monitoring where one can define
  multiple VPN network profiles on a host.
  E.g. defining a monit process called 'tinc-family' and
  another called 'tinc-friends' to watch each of the VPNs.
  To monitor them precisely use
  ...is_monitored_by('monit').with_name('tinc-family')

Test:
  Added a spec test to ensure it is working.