### PR TITLE
Adding better matcher descriptions

### DIFF
--- a/lib/serverspec/matcher/be_enabled.rb
+++ b/lib/serverspec/matcher/be_enabled.rb
@@ -7,6 +7,12 @@ RSpec::Matchers.define :be_enabled do
     end
   end
 
+  description do
+    message = 'be enabled'
+    message << " with level #{@level}" if @level
+    message
+  end
+
   chain :with_level do |level|
     @level = level
   end

--- a/lib/serverspec/matcher/be_listening.rb
+++ b/lib/serverspec/matcher/be_listening.rb
@@ -3,6 +3,13 @@ RSpec::Matchers.define :be_listening do
     port.listening? @with, @local_address
   end
 
+  description do
+    message = 'be listening'
+    message << " on #{@local_address}" if @local_address
+    message << " with #{@with}" if @with
+    message
+  end
+
   chain :with do |with|
     @with = with
   end

--- a/lib/serverspec/matcher/be_running.rb
+++ b/lib/serverspec/matcher/be_running.rb
@@ -7,6 +7,12 @@ RSpec::Matchers.define :be_running do
     end
   end
 
+  description do
+    message = 'be running'
+    message << " under #{@under}" if @under
+    message
+  end
+
   chain :under do |under|
     @under = under
   end

--- a/lib/serverspec/matcher/have_rule.rb
+++ b/lib/serverspec/matcher/have_rule.rb
@@ -7,6 +7,14 @@ RSpec::Matchers.define :have_rule do |rule|
     end
   end
 
+  description do
+    message = %Q{have rule "#{rule}"}
+    message << " with table #{@table}" if @table
+    message << ' and' if @table && @chain
+    message << " with chain #{@chain}" if @chain
+    message
+  end
+
   chain :with_table do |table|
     @table = table
   end


### PR DESCRIPTION
Summary:
  When running rspec with the '-f d' option the optional matchers
  are being omitted. This patch adds better descriptions for
   * be_enabled.rb
   * be_listening.rb
   * be_running.rb
   * have_rule.rb

Examples:
  describe service('dovecot') do
    it { should be_enabled.with_level(3) }
    it { should be_running.under('init') }
  end

  Before:
    Service "dovecot"
        should be enabled
        should be running

  After:
    Service "dovecot"
        should be enabled with level 3
        should be running under init

  ---

  describe port(143) do
    it { should be_listening.on('127.0.0.1').with('tcp') }
    it { should be_listening.on('::1').with('tcp6') }
  end

  Before:
    Port "143"
        should not be listening
        should not be listening

  After:
    Port "143"
        should be listening on 127.0.0.1 with tcp
        should be listening on ::1 with tcp6

  ---

  describe iptables do
    it { should have_rule('-j IMAP').with_chain('INPUT').with_table('filter') }
  end

  Before:
    Iptables
        should have rule "-j IMAP"

  After:
    Iptables
        should have rule "-j IMAP" with table filter and with chain INPUT