### PR TITLE
Override the selinux_module string to be 'SELinux module'

### DIFF
--- a/lib/serverspec/matcher/be_installed.rb
+++ b/lib/serverspec/matcher/be_installed.rb
@@ -1,6 +1,17 @@
 RSpec::Matchers.define :be_installed do
   match do |name|
-    name.installed?(@provider, @version)
+    if subject.class.name == 'Serverspec::Type::SelinuxModule'
+      name.installed?(@version)
+    else
+      name.installed?(@provider, @version)
+    end
+  end
+
+  description do
+    message = 'be installed'
+    message << %( by "#{@provider}") if @provider
+    message << %( with version "#{@version}") if @version
+    message
   end
 
   chain :by do |provider|

--- a/lib/serverspec/type/selinux_module.rb
+++ b/lib/serverspec/type/selinux_module.rb
@@ -4,8 +4,12 @@ module Serverspec::Type
       @runner.check_selinux_module_is_enabled(@name)
     end
 
-    def installed?(name, version=nil)
+    def installed?(version = nil)
       @runner.check_selinux_module_is_installed(@name, version)
+    end
+
+    def to_s
+      %(SELinux module "#{@name}")
     end
   end
 end

--- a/spec/type/linux/selinux_module_spec.rb
+++ b/spec/type/linux/selinux_module_spec.rb
@@ -4,6 +4,10 @@ set :os, :family => 'linux'
 
 describe selinux_module('bootloader') do
   it { should be_installed }
+end 
+
+describe selinux_module('bootloader') do
+  it { should be_installed.with_version('1.10') }
 end
 
 describe selinux_module('bootloader') do


### PR DESCRIPTION
Summary:
  When running rspec in '-f d' mode the selinux type says 'SELinux'
  while the selinux_module type read 'Selinux module'. With this
  change it is now 'SELinux module'. Plus better descriptions for
  the types selinux_module and package.

  Type selinux_module:

  describe selinux_module('bootloader') do
    it { should be_installed }
  end

  describe selinux_module('bootloader') do
    it { should be_installed.with_version('1.10') }
  end

  Before:
    Selinux module "bootloader"
      should be enabled

    Selinux module "bootloader"
      should be enabled

  After:
    SELinux module "bootloader"
      should be enabled

    SELinux module "bootloader"
      should be enabled with version "1.10"

  Type package:

  describe package('jekyll') do
    it { should be_installed.by(:gem) }
  end

  describe package('jekyll') do
    it { should be_installed.by(:gem).with_version('1.1.1') }
  end

  Before:
    Package "jekyll"
      should be installed

    Package "jekyll"
      should be installed

  After:
    Package "jekyll"
      should be installed by "gem"

    Package "jekyll"
      should be installed by "gem" with version "1.1.1"