### PR TITLE
adding new its(:ipv4/v6_address) feature to interface resource

### DIFF
--- a/lib/serverspec/type/interface.rb
+++ b/lib/serverspec/type/interface.rb
@@ -22,6 +22,14 @@ module Serverspec::Type
       @runner.check_interface_has_ipv6_address(@name, ip_address)
     end
 
+    def ipv4_address
+      @runner.get_interface_ipv4_address(@name).stdout.strip
+    end
+
+    def ipv6_address
+      @runner.get_interface_ipv6_address(@name).stdout.strip
+    end
+
     def up?
       ret = @runner.get_interface_link_state(@name)
       ret.stdout.strip == 'up'

--- a/spec/type/linux/interface_spec.rb
+++ b/spec/type/linux/interface_spec.rb
@@ -24,6 +24,16 @@ describe interface('eth0') do
   it { should have_ipv6_address('2001:0db8:bd05:01d2:288a:1fc0:0001:10ee') }
 end
 
+describe interface('eth1') do
+  let(:stdout) { "1.2.3.4/1\r\n" }
+  its(:ipv4_address) { should match(/^[\d.]+\/\d+$/) }
+end
+
+describe interface('eth1') do
+  let(:stdout) { "2001:db8::1234/1\r\n" }
+  its(:ipv6_address) { should match(/^[a-f\d:]+\/\d+$/i) }
+end
+
 describe interface('eth0') do
   let(:stdout) { 'up' }
   it { should be_up }
@@ -38,4 +48,3 @@ describe interface('invalid-interface') do
   let(:stdout) { '9001' }
   its(:mtu) { should_not eq 1500 }
 end
-

--- a/spec/type/openbsd/interface_spec.rb
+++ b/spec/type/openbsd/interface_spec.rb
@@ -15,6 +15,16 @@ describe interface('eth0') do
   it { should have_ipv4_address("192.168.10.10/24") }
 end
 
+describe interface('eth1') do
+  let(:stdout) { "1.2.3.4/1\r\n" }
+  its(:ipv4_address) { should match(/^[\d.]+\/\d+$/) }
+end
+
+describe interface('eth1') do
+  let(:stdout) { "2001:db8::1234/1\r\n" }
+  its(:ipv6_address) { should match(/^[a-f\d:]+\/\d+$/i) }
+end
+
 describe interface('invalid-interface') do
   let(:stdout) { '1000' }
   its(:speed) { should_not eq 100 }


### PR DESCRIPTION
Finishing new feature started in mizzy/specinfra#528. Please add `its(:ipv4_address)` and `its(:ipv6_address)` to the interface resource in the documentation.