### PR TITLE
build_command expects string, not class for windows file

### DIFF
--- a/lib/serverspec/type/file.rb
+++ b/lib/serverspec/type/file.rb
@@ -6,7 +6,7 @@ module Serverspec::Type
 
     def file?
       cmd = Specinfra.command.get(:check_file_is_file, @name)
-      @inspection = Specinfra.backend.build_command(cmd)
+      @inspection = Specinfra.backend.build_command(cmd.to_s)
       @runner.check_file_is_file(@name)
     end
 


### PR DESCRIPTION
build_command expects string, not class for windows file
fixes the error :
```
            Failure/Error: it { should be_file }
            NoMethodError:
       undefined method `strip!' for #<Specinfra::Backend::PowerShell::Command:0x302c9b8>
```