### PR TITLE
Enhancement: server spec for php extensions

### DIFF
--- a/lib/serverspec/helper/type.rb
+++ b/lib/serverspec/helper/type.rb
@@ -10,7 +10,7 @@ module Serverspec
         windows_feature windows_hot_fix windows_registry_key
         windows_scheduled_task zfs docker_base docker_image
         docker_container x509_certificate x509_private_key
-        linux_audit_system hadoop_config
+        linux_audit_system hadoop_config php_extension
       )
 
       types.each {|type| require "serverspec/type/#{type}" }

--- a/lib/serverspec/type/php_extension.rb
+++ b/lib/serverspec/type/php_extension.rb
@@ -1,0 +1,11 @@
+module Serverspec::Type
+  class PhpExtension < Base
+    def loaded?
+      ret = @runner.run_command("php --ri '#{@name}'")
+
+      return false if ret.exit_status.to_i > 0
+
+      true
+    end
+  end
+end

--- a/spec/type/base/php_extension_spec.rb
+++ b/spec/type/base/php_extension_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+set :os, :family => 'base'
+
+describe php_extension('tillext') do
+  let(:exit_status) { 1 }
+  it { should_not be_loaded }
+end
+
+describe php_extension('session') do
+  let(:exit_status) { 0 }
+  it { should be_loaded }
+end


### PR DESCRIPTION
So, I want to ensure the proper configuration is setup and the PHP extension is loaded.

```
describe php_ext('apc') do
  it { should_be loaded }
end