### PR TITLE
add resource type json file

### DIFF
--- a/lib/serverspec/helper/type.rb
+++ b/lib/serverspec/helper/type.rb
@@ -4,7 +4,7 @@ module Serverspec
       types = %w(
         base bridge bond cgroup command cron default_gateway file fstab
         group host iis_website iis_app_pool interface ipfilter ipnat
-        iptables ip6tables kernel_module linux_kernel_parameter lxc
+        iptables ip6tables json_file kernel_module linux_kernel_parameter lxc
         mail_alias mysql_config package php_config port ppa process
         routing_table selinux selinux_module service user yumrepo
         windows_feature windows_hot_fix windows_registry_key

--- a/lib/serverspec/type/json_file.rb
+++ b/lib/serverspec/type/json_file.rb
@@ -1,0 +1,9 @@
+require 'json'
+
+module Serverspec::Type
+  class JsonFile < File
+    def content
+      JSON.parse(super)
+    end
+  end
+end

--- a/spec/type/base/json_file_spec.rb
+++ b/spec/type/base/json_file_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+set :os, {:family => 'base'}
+
+describe json_file('example.json') do
+  let(:stdout) {<<EOF
+{
+  "json": {
+    "title": "this is a json",
+    "array" : [
+      {
+        "title": "array 1"
+      },
+      {
+        "title": "array 2"
+      }
+    ]
+  }
+}
+EOF
+  }
+
+  its(:content) { should include('json') }
+  its(:content) { should include('json' => include('title' => 'this is a json')) }
+  its(:content) { should include('json' => include('array' => include('title' => 'array 2'))) }
+end
+


### PR DESCRIPTION
I want to test json file (for example, consul config file) by include matcher with serverspec.

```
describe json_file('foo.json') do
  its(:content) { should include('foo' => include('bar' => 'hoge')) }
end
```