### PR TITLE
add `its(:content_as_json)` to file resource type

### DIFF
--- a/lib/serverspec/type/file.rb
+++ b/lib/serverspec/type/file.rb
@@ -1,4 +1,5 @@
 require 'date'
+require 'multi_json'
 
 module Serverspec::Type
   class File < Base
@@ -111,6 +112,14 @@ module Serverspec::Type
         @content = @runner.get_file_content(@name).stdout
       end
       @content
+    end
+
+    def content_as_json
+      if @content_as_json.nil?
+        @content = @runner.get_file_content(@name).stdout if @content.nil?
+        @content_as_json = MultiJson.load(@content)
+      end
+      @content_as_json
     end
 
     def group

--- a/spec/type/base/file_spec.rb
+++ b/spec/type/base/file_spec.rb
@@ -342,6 +342,29 @@ EOF
   its(:content) { should match /root:x:0:0/ }
 end
 
+describe file('example.json') do
+  let(:stdout) {<<EOF
+{
+  "json": {
+    "title": "this is a json",
+    "array" : [
+      {
+        "title": "array 1"
+      },
+      {
+        "title": "array 2"
+      }
+    ]
+  }
+}
+EOF
+  }
+
+  its(:content_as_json) { should include('json') }
+  its(:content_as_json) { should include('json' => include('title' => 'this is a json')) }
+  its(:content_as_json) { should include('json' => include('array' => include('title' => 'array 2'))) }
+end
+
 describe file('/etc/pam.d/system-auth') do
   let(:stdout) { "/etc/pam.dsystem-auth-ac\r\n" }
   its(:link_target) { should eq '/etc/pam.dsystem-auth-ac' }


### PR DESCRIPTION
To test JSON file, add `its(:content_as_json)` to file resource type.

usage

```
describe file('example.json') do
  its(:content_as_json) { should include('foo' => include('bar' => 'hoge')) }
end
```

example.json

```
{
  "foo": {
    "bar": "hoge"
  }
}
```
