### PR TITLE
add `its(:content_as_yaml)` to file resource type

### DIFF
--- a/lib/serverspec/type/file.rb
+++ b/lib/serverspec/type/file.rb
@@ -1,5 +1,6 @@
 require 'date'
 require 'multi_json'
+require 'yaml'
 
 module Serverspec::Type
   class File < Base
@@ -120,6 +121,11 @@ module Serverspec::Type
         @content_as_json = MultiJson.load(@content)
       end
       @content_as_json
+    end
+
+    def content_as_yaml
+      @content_as_yaml = YAML.load(content) if @content_as_yaml.nil?
+      @content_as_yaml
     end
 
     def group

--- a/spec/type/base/file_spec.rb
+++ b/spec/type/base/file_spec.rb
@@ -365,6 +365,25 @@ EOF
   its(:content_as_json) { should include('json' => include('array' => include('title' => 'array 2'))) }
 end
 
+describe file('example.yml') do
+  let(:stdout) {<<EOF
+---
+yaml:
+  title: 'this is a yaml'
+  array:
+    -
+      title: 'array 1'
+    -
+      title: 'array 2'
+EOF
+  }
+
+  its(:content_as_yaml) { should include('yaml') }
+  its(:content_as_yaml) { should include('yaml' => include('title' => 'this is a yaml')) }
+  its(:content_as_yaml) { should include('yaml' => include('array' => include('title' => 'array 2'))) }
+end
+
+
 describe file('/etc/pam.d/system-auth') do
   let(:stdout) { "/etc/pam.dsystem-auth-ac\r\n" }
   its(:link_target) { should eq '/etc/pam.dsystem-auth-ac' }


### PR DESCRIPTION
To test YAML file, add `its(:content_as_yaml)` to file resource type.

usage

```
describe file('example.yml') do
  its(:content_as_yaml) { should include('foo' => include('bar' => 'hoge')) }
end
```


example.yml

```
---
foo:
  bar: hoge
```
