### PR TITLE
Add X509Certificate#subject_alt_names

### DIFF
--- a/lib/serverspec/type/x509_certificate.rb
+++ b/lib/serverspec/type/x509_certificate.rb
@@ -60,6 +60,15 @@ module Serverspec::Type
       ( diff/(60*60*24) )
     end
 
+    def subject_alt_names
+      text = run_openssl_command_with('-text -noout').stdout
+      # X509v3 Subject Alternative Name:
+      #     DNS:*.example.com, DNS:www.example.net, IP:192.0.2.10
+      if text =~ /^ *X509v3 Subject Alternative Name: *\n *(.*)$/
+        $1.split(/, +/)
+      end
+    end
+
     private
     def run_openssl_command_with(param_str)
       @runner.run_command("openssl x509 -in #{name} #{param_str}")

--- a/spec/type/linux/x509_certificate_spec.rb
+++ b/spec/type/linux/x509_certificate_spec.rb
@@ -33,6 +33,10 @@ describe x509_certificate('test.pem') do
   it { should_not be_valid }
 end
 
+describe x509_certificate('test.pem') do
+  let(:stdout) { sample_san }
+  its(:subject_alt_names) { should eq %w[DNS:*.example.com DNS:www.example.net IP:192.0.2.10] }
+end
 
 def sample_subj
   <<'EOS'
@@ -60,3 +64,15 @@ notAfter=Jul  1 11:11:00 2010 GMT
 EOS
 end
 
+def sample_san
+  <<'EOS'
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        X509v3 extensions:
+            X509v3 Extended Key Usage:
+                TLS Web Server Authentication, TLS Web Client Authentication
+            X509v3 Subject Alternative Name:
+                DNS:*.example.com, DNS:www.example.net, IP:192.0.2.10
+EOS
+end


### PR DESCRIPTION
Hi mizzy-san.

This patch adds `X509Certificate#subject_alt_names` method so that we can write a spec that a certificate have a certain subject alternative name.