### PR TITLE
Cleaned up expectation syntax to remove previous warnings when running tests

### DIFF
--- a/spec/type/aix/file_spec.rb
+++ b/spec/type/aix/file_spec.rb
@@ -18,7 +18,7 @@ describe file('/etc/passwd') do
   it 'be_mode is not implemented' do
     expect {
       should be_mode 644
-    }.to raise_exception
+    }.to raise_error(/is not implemented in Specinfra/)
   end
 end
 

--- a/spec/type/base/file_spec.rb
+++ b/spec/type/base/file_spec.rb
@@ -413,6 +413,6 @@ describe file('/etc/passwd') do
   it 'be_immutable is not implemented in base class' do
     expect {
       should be_immutable
-    }.to raise_exception
+    }.to raise_error(/is not implemented in Specinfra/)
   end
 end

--- a/spec/type/base/service_spec.rb
+++ b/spec/type/base/service_spec.rb
@@ -27,7 +27,7 @@ describe service('sshd') do
   it {
     expect {
       should be_running.under('not implemented')
-    }.to raise_exception
+    }.to raise_error(/is not implemented in Specinfra/)
   }
 end
 
@@ -49,6 +49,6 @@ describe service('sshd') do
   it {
     expect {
       should be_monitored_by('not implemented')
-    }.to raise_exception
+    }.to raise_error(NotImplementedError)
   }
 end

--- a/spec/type/solaris10/file_spec.rb
+++ b/spec/type/solaris10/file_spec.rb
@@ -308,6 +308,6 @@ describe file('/etc/passwd') do
   it 'be_immutable is not implemented in base class' do
     expect {
       should be_immutable
-    }.to raise_exception
+    }.to raise_error(/is not implemented in Specinfra/)
   end
 end

--- a/spec/type/windows/file_spec.rb
+++ b/spec/type/windows/file_spec.rb
@@ -39,7 +39,7 @@ end
 describe file('/some/file') do
   it "should raise error if trying to check access by 'owner' or 'group' or 'others'" do
    ['owner', 'group', 'others'].each do |access|
-     expect { should be_readable.by(access) }.to raise_error
+     expect { should be_readable.by(access) }.to raise_error(RuntimeError)
    end
  end
 end
@@ -59,7 +59,7 @@ end
 describe file('/some/file') do
   it "should raise error if trying to check access by 'owner' or 'group' or 'others'" do
    ['owner', 'group', 'others'].each do |access|
-     expect { should be_writable.by(access) }.to raise_error
+     expect { should be_writable.by(access) }.to raise_error(RuntimeError)
    end
  end
 end
@@ -79,7 +79,7 @@ end
 describe file('/some/file') do
   it "should raise error if trying to check access by 'owner' or 'group' or 'others'" do
    ['owner', 'group', 'others'].each do |access|
-     expect { should be_executable.by(access) }.to raise_error
+     expect { should be_executable.by(access) }.to raise_error(RuntimeError)
    end
  end
 end
@@ -97,17 +97,24 @@ describe file('/some/file') do
 end
 
 describe file('/some/test/file') do
-  it "should raise error if command is not supported" do 
+  it "should raise error if command is not implemented" do
     {
       :be_socket => [],
       :be_mode => 644,
       :be_grouped_into => 'root',
       :be_linked_to => '/some/other/file',
-      :be_mounted => [],
+      :be_mounted => []
+    }.each do |method, args|
+      expect { should self.send(method, *args) }.to raise_error(NotImplementedError)
+    end
+  end
+
+  it "should raise error if command is not defined" do
+    {
       :match_md5checksum => '35435ea447c19f0ea5ef971837ab9ced',
       :match_sha256checksum => '0c3feee1353a8459f8c7d84885e6bc602ef853751ffdbce3e3b6dfa1d345fc7a'
     }.each do |method, args|
-      expect { should self.send(method, *args) }.to raise_exception
+      expect { should self.send(method, *args) }.to raise_error(NoMethodError)
     end
   end
 end

--- a/spec/type/windows/group_spec.rb
+++ b/spec/type/windows/group_spec.rb
@@ -17,7 +17,7 @@ describe group('test.group') do
     {
       :have_gid => [nil],
     }.each do |method, args|
-      expect { should self.send(method, *args) }.to raise_exception
+      expect { should self.send(method, *args) }.to raise_error(NotImplementedError)
     end
   end
 end

--- a/spec/type/windows/service_spec.rb
+++ b/spec/type/windows/service_spec.rb
@@ -22,9 +22,9 @@ end
 
 describe service('Test service') do
   it "should raise error if trying to check service process controller" do
-   expect { should be_running.under('supervisor') }.to raise_error
+   expect { should be_running.under('supervisor') }.to raise_error(NotImplementedError)
  end
   it "should raise error if trying to check service monitoring" do
-   expect { should_not be_monitored_by('monit') }.to raise_error
+   expect { should_not be_monitored_by('monit') }.to raise_error(NotImplementedError)
  end
 end

--- a/spec/type/windows/user_spec.rb
+++ b/spec/type/windows/user_spec.rb
@@ -27,7 +27,7 @@ describe user('test.user') do
       :have_login_shell => [nil],
       :have_authorized_key => [nil],
     }.each do |method, args|
-      expect { should self.send(method, *args) }.to raise_exception
+      expect { should self.send(method, *args) }.to raise_error(NotImplementedError)
     end
   end
 end


### PR DESCRIPTION
Replaced generic catch statements with fine-grained expectations of NoMethod etc.
