### PR TITLE
Bump specinfra gem from 2.53 to 2.59.6

### DIFF
--- a/serverspec.gemspec
+++ b/serverspec.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "rspec", "~> 3.0"
   spec.add_runtime_dependency "rspec-its"
   spec.add_runtime_dependency "multi_json"
-  spec.add_runtime_dependency "specinfra", "~> 2.53"
+  spec.add_runtime_dependency "specinfra", "~> 2.59.6"
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency("json", "~> 1.8") if RUBY_VERSION < "1.9"
   spec.add_development_dependency "rake", "~> 10.1.1"


### PR DESCRIPTION
I pulled the full change log out of the [releases for specinfra](https://github.com/mizzy/specinfra/releases), I'm specifically bumping for the latest change I had merged there. We found that some tests failed when asserting that `homebrew_cask` installed some brew packages and a fix was put into specinfra. 

Changes
---
- Cask now uses 2 separate potential files locations
- Ignore "system_user" option for user creation on FreeBSD.
- Check if kernel module is loaded on Solaris
- Add protocol options to darwin port listening check
- Fix subclasses singleton_class check
- pip and gem check_is_installed false successes
- host_inventory: use kenv to get the system product name on FreeBSD
- Added default task to run rake spec:all
- Fix mail_alias_spec filename
- Isolate specs so the whole suite can be run
- host_inventory: use systemd-detect-virt for virtualization detection
- Support host_inventory['group']
- Add check that symlinks can be fully resolved to their real path
- Support host_inventory['user']
- Support the init system for Alpine Linux
- Use sed instead of grep and cut
- Close communication pipes after process finished
- Use cut instead of awk
- Support Ubuntu v16.xx
- Add support for Cygwin
- Support fluentd plugin installed check command
- Consume remained stdout and stderr from buffer
- multiple commands needs to be executes as $(commands)
- Allowing the use of net-ssh < 4.0 if using Ruby 2.0+
- SLES 12 Support
- Use Write-Host instead of Out-String for Windows file content
- Docker backend accepts send_file when base_image isn't set, but container is set
- Add options to Command::Base::File
- Return $TRUE and $FALSE in Windows is_owned_by command
- Allow backslash in crontab

