### PR TITLE
Fixed 'be_mode' test for AIX as it no longer raises an 'unimplemented' exception

### DIFF
--- a/spec/type/aix/file_spec.rb
+++ b/spec/type/aix/file_spec.rb
@@ -15,11 +15,7 @@ describe file('/tmp') do
 end
 
 describe file('/etc/passwd') do
-  it 'be_mode is not implemented' do
-    expect {
-      should be_mode 644
-    }.to raise_error(/is not implemented in Specinfra/)
-  end
+  it { should be_mode 644 }
 end
 
 describe file('/etc/passwd') do


### PR DESCRIPTION
ServerSpec test in 'spec/type/aix/file_spec.rb' gave false error since SpecInfra now implements 'be_mode' for AIX.

Going forward, I suggest making sure all ServerSpec tests be run and validated every time a push to SpecInfra is made.
