### PR TITLE
More consistent use of JSON interpreter

### DIFF
--- a/lib/serverspec/type/json_file.rb
+++ b/lib/serverspec/type/json_file.rb
@@ -1,9 +1,9 @@
-require 'json'
+require 'multi_json'
 
 module Serverspec::Type
   class JsonFile < File
     def content
-      JSON.parse(super)
+      MultiJson.load(super)
     end
   end
 end

--- a/spec/type/linux/docker_container_spec.rb
+++ b/spec/type/linux/docker_container_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 require 'spec_helper'
-require 'json'
+require 'multi_json'
 
 property[:os] = nil
 set :os, {:family => 'linux'}
@@ -21,7 +21,7 @@ end
 
 describe docker_container('restarting') do
   let(:stdout) do
-    attrs = JSON.parse(inspect_container)
+    attrs = MultiJson.load(inspect_container)
     attrs.first['State']['Restarting'] = true
     attrs.to_json
   end


### PR DESCRIPTION
Generally it shouldn't be an issue to use the `json` interpreter directly. However, with certain configurations (CentOS, Amazon Linux, Arch) it might be that the otherwise internal `json` interpreter isn't included by default or living outside the MRI tree. For these occasions you will need to include a JSON interpreter of your choice or have your specs break randomly (`json_file` in particular).

Since the project is already making extensive use of `multi_json` I found it appropriate to use it instead of `json` where possible to give the user a choice.

Functionality is retained, all specs are still valid.