### PR TITLE
correctly grab index for docker inspection

### DIFF
--- a/lib/serverspec/type/docker_base.rb
+++ b/lib/serverspec/type/docker_base.rb
@@ -10,7 +10,7 @@ module Serverspec::Type
       value = inspection
       key.split('.').each do |k|
         is_index = k.start_with?('[') && k.end_with?(']')
-        value = value[is_index ? k.to_i : k]
+        value = value[is_index ? k[1..-2].to_i : k]
       end
       value
     end

--- a/spec/type/linux/docker_container_spec.rb
+++ b/spec/type/linux/docker_container_spec.rb
@@ -17,6 +17,7 @@ describe docker_container('c1') do
   its(:inspection) { should include 'Driver' => 'aufs' }
   its(['Config.Cmd']) { should include '/bin/sh' }
   its(['HostConfig.PortBindings.80.[0].HostPort']) { should eq '8080' }
+  its(['HostConfig.PortBindings.80.[1].HostPort']) { should eq '8081' }  
 end
 
 describe docker_container('restarting') do
@@ -80,6 +81,10 @@ def inspect_container
                 {
                     "HostIp": "",
                     "HostPort": "8080"
+                },
+                {
+                    "HostIp": "",
+                    "HostPort": "8081"
                 }
             ]
         },


### PR DESCRIPTION
.to_i conveniently returns 0 for all string values that are not integers.. actually grabbing the desired index here
cc: @DarrellMozingo 