### PR TITLE
[WIP] command stdout_as_json feature request

### DIFF
--- a/lib/serverspec/type/command.rb
+++ b/lib/serverspec/type/command.rb
@@ -1,7 +1,13 @@
+require 'multi_json'
+
 module Serverspec::Type
   class Command < Base
     def stdout
       command_result.stdout
+    end
+
+    def stdout_as_json
+      MultiJson.load(command_result.stdout)
     end
 
     def stderr

--- a/spec/type/base/command_spec.rb
+++ b/spec/type/base/command_spec.rb
@@ -65,3 +65,42 @@ EOF
   its(:stdout) { should contain('4260').before('home') }
   its(:stdout) { should_not contain('4260').before('bin') }
 end
+
+describe command('curl http://localhost:8080/info') do
+  let(:stdout) { <<EOF
+{
+   "sensu":{
+      "version":"0.26.5"
+   },
+   "transport":{
+      "keepalives":{
+         "messages":0,
+         "consumers":1
+      },
+      "results":{
+         "messages":0,
+         "consumers":1
+      },
+      "connected":true
+   },
+   "redis":{
+      "connected":true
+   },
+   "array":[
+      {
+         "title":"array 1"
+      },
+      {
+         "title":"array 2"
+      }
+   ]
+}
+EOF
+  }
+
+  its(:stdout_as_json) { should include('sensu') }
+  its(:stdout_as_json) { should include('sensu' => include('version' => '0.26.5')) }
+  its(:stdout_as_json) { should include('transport' => include('keepalives' => include('consumers' => 1))) }
+  its(:stdout_as_json) { should include('transport' => include('connected' => true)) }
+  its(:stdout_as_json) { should include('array' => include('title' => 'array 2')) }
+end


### PR DESCRIPTION
# Context
Many newer apps (e.g. Sensu, Springboot apps) have `/info`, `/health` or `/env` endpoints that output JSON content about the app's state. It would be very useful to be able to assert the values on these endpoints to make sure an app provisioned with Chef is actually up and health as part of our Chef integration test suite.

# Feature Request
- I've followed this [example](https://github.com/mizzy/serverspec/pull/566/files) to add the ability to assert on the result of curling these endpoints
- I've used the `command` resource here, but I was wondering if maybe a new `curl` resource is appropriate instead? (I'm new to Ruby, so this is mostly a feature request I'm hoping someone with more experience can implement)