### PR TITLE
subject_alt_names fails when are marked critical

### DIFF
--- a/lib/serverspec/type/x509_certificate.rb
+++ b/lib/serverspec/type/x509_certificate.rb
@@ -64,7 +64,7 @@ module Serverspec::Type
       text = run_openssl_command_with('-text -noout').stdout
       # X509v3 Subject Alternative Name:
       #     DNS:*.example.com, DNS:www.example.net, IP:192.0.2.10
-      if text =~ /^ *X509v3 Subject Alternative Name: *\n *(.*)$/
+      if text =~ /^ *X509v3 Subject Alternative Name:.*\n *(.*)$/
         $1.split(/, +/)
       end
     end


### PR DESCRIPTION
RFC5282 stated that Subject Alternative Name must be marked critical when Subject is empty [1].
In this case openssl returns:
```
...
X509v3 extensions:
    X509v3 Subject Alternative Name: critical
        DNS:example.local, IP Address:192.0.2.1
...
```
and subject_alt_names can't get Subject Alternative Names.

[1] https://tools.ietf.org/html/rfc5280#section-4.2.1.6