### PR TITLE
Add support for PKCS#8 format to X509PrivateKey#encrypted?

### DIFF
--- a/lib/serverspec/type/x509_private_key.rb
+++ b/lib/serverspec/type/x509_private_key.rb
@@ -8,7 +8,7 @@ module Serverspec::Type
     end
 
     def encrypted?
-      @runner.run_command("grep -wq \"^Proc-Type.*ENCRYPTED$\" #{name}").exit_status == 0
+      @runner.run_command("grep -Ewq \"^(Proc-Type.*ENCRYPTED|-----BEGIN ENCRYPTED PRIVATE KEY-----)$\" #{name}").exit_status == 0
     end
 
     def has_matching_certificate?(cert_file)


### PR DESCRIPTION
X509PrivateKey#encrypted? supports only old format of RSA encrypted
private key. This PR adds support for PKCS#8 format (see RFC7468).