### PR TITLE
Add a basic set of windows firewall checks

### DIFF
--- a/lib/serverspec/helper/type.rb
+++ b/lib/serverspec/helper/type.rb
@@ -10,7 +10,7 @@ module Serverspec
         windows_feature windows_hot_fix windows_registry_key
         windows_scheduled_task zfs docker_base docker_image
         docker_container x509_certificate x509_private_key
-        linux_audit_system hadoop_config php_extension
+        linux_audit_system hadoop_config php_extension windows_firewall
       )
 
       types.each {|type| require "serverspec/type/#{type}" }

--- a/lib/serverspec/type/windows_firewall.rb
+++ b/lib/serverspec/type/windows_firewall.rb
@@ -1,0 +1,28 @@
+module Serverspec::Type
+  class WindowsFirewall < Base
+    def exists?
+      @runner.check_firewall_exists(@name)
+    end
+
+    def tcp?
+      @runner.check_firewall_has_protocol(@name, 'TCP')
+    end
+
+    def has_localport?(port)
+      @runner.check_firewall_has_localport(@name, port)
+    end
+
+    def inbound?
+      @runner.check_firewall_has_direction(@name, 'Inbound')
+    end
+
+    def enabled?
+      @runner.check_firewall_is_enabled(@name)
+    end
+
+    def allowed?
+      @runner.check_firewall_has_action(@name, 'Allow')
+    end
+
+  end
+end


### PR DESCRIPTION
Corresponding to the specinfra changes submitted yesterday.

```
describe windows_firewall('Rule 2345') do
  it { should exist }
  it { should be_tcp }
  it { should have_localport(2345) }
  it { should be_inbound }
  it { should be_enabled }
  it { should be_allowed }
end
```