### PR TITLE
Accept OpenSSL 1.1 X.509 certificate informations

### DIFF
--- a/lib/serverspec/type/x509_certificate.rb
+++ b/lib/serverspec/type/x509_certificate.rb
@@ -7,11 +7,11 @@ module Serverspec::Type
     end
 
     def subject
-      run_openssl_command_with("-subject -noout").stdout.chomp.gsub(/^subject= /,'')
+      run_openssl_command_with("-subject -noout").stdout.chomp.gsub(/^subject= */,'')
     end
 
     def issuer
-      run_openssl_command_with("-issuer -noout").stdout.chomp.gsub(/^issuer= /,'')
+      run_openssl_command_with("-issuer -noout").stdout.chomp.gsub(/^issuer= */,'')
     end
 
     def email


### PR DESCRIPTION
OpenSSL 1.1 has changed the output of X.509 certificate informations.

OpenSSL 1.0 on CentOS 7:
```bash
# openssl version
OpenSSL 1.0.2k-fips  26 Jan 2017
# openssl x509 -in /etc/ssl/certs/ca.crt -noout -issuer
issuer= /CN=Simple CA
# openssl x509 -in /etc/ssl/certs/ca.crt -noout -subject
subject= /CN=Simple CA
```

OpenSSL 1.1 on Debian 9:
```bash
# openssl version
OpenSSL 1.1.0f  25 May 2017
# openssl x509 -in /etc/ssl/certs/ca.crt -noout -issuer
issuer=CN = Simple CA
# openssl x509 -in /etc/ssl/certs/ca.crt -noout -subject
subject=CN = Simple CA
```