### PR TITLE
Fix infinite loop in Specinfra::Configuration.os fall back

### DIFF
--- a/lib/serverspec.rb
+++ b/lib/serverspec.rb
@@ -1,7 +1,7 @@
 require 'rubygems'
-require 'specinfra'
 require 'rspec'
 require 'rspec/its'
+require 'specinfra'
 require 'serverspec/version'
 require 'serverspec/matcher'
 require 'serverspec/helper'


### PR DESCRIPTION
## How to reproduce infinite loop

```
% bundle exec irb -r serverspec
irb(main):001:0> os
SystemStackError: stack level too deep
        from /home/masaru/.asdf/installs/ruby/2.4.0/lib/ruby/gems/2.4.0/gems/specinfra-2.72.0/lib/specinfra/properties.rb:10:in `properties'
        from /home/masaru/.asdf/installs/ruby/2.4.0/lib/ruby/gems/2.4.0/gems/specinfra-2.72.0/lib/specinfra/helper/properties.rb:7:in `property'
        ...
        ...
```

## How to fix

Require rspec before specinfra.

## Note

 For the test framework itself is RSpec, I couldn't write a test about this issue.