### PR TITLE
Fix be_installed matcher when used with expect

### DIFF
--- a/lib/serverspec/matcher/be_installed.rb
+++ b/lib/serverspec/matcher/be_installed.rb
@@ -1,9 +1,9 @@
 RSpec::Matchers.define :be_installed do
-  match do |name|
-    if name.class.name == 'Serverspec::Type::SelinuxModule'
-      name.installed?(@version)
+  match do |subject|
+    if subject.class.name == 'Serverspec::Type::SelinuxModule'
+      subject.installed?(@version)
     else
-      name.installed?(@provider, @version)
+      subject.installed?(@provider, @version)
     end
   end
 

--- a/lib/serverspec/matcher/be_installed.rb
+++ b/lib/serverspec/matcher/be_installed.rb
@@ -1,6 +1,6 @@
 RSpec::Matchers.define :be_installed do
   match do |name|
-    if subject.class.name == 'Serverspec::Type::SelinuxModule'
+    if name.class.name == 'Serverspec::Type::SelinuxModule'
       name.installed?(@version)
     else
       name.installed?(@provider, @version)


### PR DESCRIPTION
When used like

  expect(package('httpd')).to be_installed

it causes an error that subject is not defined

  undefined local variable or method `subject' for
  #<RSpec::Matchers::DSL::Matcher be_installed> (NameError)

It should be changed to use the passed #match parameter 'name'
instead of 'subject'.