### PR TITLE
This change is to extend search scope for cron entries.

### DIFF
--- a/lib/serverspec/type/cron.rb
+++ b/lib/serverspec/type/cron.rb
@@ -8,6 +8,10 @@ module Serverspec::Type
       @runner.get_cron_table.stdout
     end
 
+    def anywhere
+      @runner.get_cron_anywhere.stdout
+    end
+
     def to_s
       'Cron'
     end


### PR DESCRIPTION
This is a pull request to test if there is a given entry anywhere specified by Vixie Cron.


Sample:
```
describe cron do
  its(:anywhere) { should match /10 10 \* \* \* root touch \/tmp\/testfile/ }
end
```

This change depends on the following pull request:
https://github.com/mizzy/specinfra/pull/649

Thanks.