### PR TITLE
Adds features to docker containers

### DIFF
--- a/lib/serverspec/type/docker_container.rb
+++ b/lib/serverspec/type/docker_container.rb
@@ -12,6 +12,16 @@ module Serverspec::Type
       end
     end
 
+    def uptime
+      started_time = Time.parse(inspection['State']['StartedAt']).localtime
+      duration_in_seconds = (Time.now - started_time).to_i
+      if inspection['State']['Running']
+        return duration_in_seconds
+      else
+        return nil
+      end
+    end
+
     private
     def check_volume(container_path, host_path)
       inspection['Mounts'].find {|mount|

--- a/spec/type/aix/service_spec.rb
+++ b/spec/type/aix/service_spec.rb
@@ -3,10 +3,65 @@ require 'spec_helper'
 set :os, :family => 'aix'
 
 describe service('sshd') do
+  let(:stdout) { inspect_service }
   it { should be_enabled }
+  its('number_of_restarts') { should be 0 }
+  its(:inspection) { should include 'MemoryCurrent' => '4067328' }
+  its(['RestartUSec']) { should eq '42s' }
 end
 
 describe service('sshd') do
   it { should be_enabled.with_level(4) }
 end
 
+def inspect_service
+  <<'EOS'
+Type=notify
+Restart=on-failure
+NotifyAccess=main
+RestartUSec=42s
+TimeoutStartUSec=1min 30s
+TimeoutStopUSec=1min 30s
+WatchdogUSec=0
+WatchdogTimestamp=Mon 2018-01-08 13:18:51 CST
+WatchdogTimestampMonotonic=16678908
+StartLimitInterval=10000000
+StartLimitBurst=5
+StartLimitAction=none
+FailureAction=none
+PermissionsStartOnly=no
+RootDirectoryStartOnly=no
+RemainAfterExit=no
+GuessMainPID=yes
+MainPID=971
+ControlPID=0
+FileDescriptorStoreMax=0
+StatusErrno=0
+Result=success
+ExecMainStartTimestamp=Mon 2018-01-08 13:18:51 CST
+ExecMainStartTimestampMonotonic=16538549
+ExecMainExitTimestampMonotonic=0
+ExecMainPID=971
+ExecMainCode=0
+ExecMainStatus=0
+ExecStart={ path=/usr/sbin/sshd ; argv[]=/usr/sbin/sshd -D $OPTIONS ; ignore_errors=no ; start_time=[Mon 2018-01-08 13:18:51 CST] ; stop_time=[n/a] ; pid=971 ; code=(null) ; status=0/0 }
+ExecReload={ path=/bin/kill ; argv[]=/bin/kill -HUP $MAINPID ; ignore_errors=no ; start_time=[n/a] ; stop_time=[n/a] ; pid=0 ; code=(null) ; status=0/0 }
+Slice=system.slice
+ControlGroup=/system.slice/sshd.service
+MemoryCurrent=4067328
+Delegate=no
+CPUAccounting=no
+CPUShares=18446744073709551615
+StartupCPUShares=18446744073709551615
+CPUQuotaPerSecUSec=infinity
+BlockIOAccounting=no
+BlockIOWeight=18446744073709551615
+StartupBlockIOWeight=18446744073709551615
+MemoryAccounting=no
+MemoryLimit=18446744073709551615
+DevicePolicy=auto
+EnvironmentFile=/etc/sysconfig/sshd (ignore_errors=no)
+UMask=0022
+LimitCPU=18446744073709551615
+EOS
+end

--- a/spec/type/linux/docker_container_spec.rb
+++ b/spec/type/linux/docker_container_spec.rb
@@ -14,10 +14,11 @@ describe docker_container('c1') do
   it { should be_running }
   it { should have_volume('/tmp', '/data') }
   it { should_not have_volume('/tmp', '/data-bad') }
+  its(:uptime) { should be > 4 }
   its(:inspection) { should include 'Driver' => 'aufs' }
   its(['Config.Cmd']) { should include '/bin/sh' }
   its(['HostConfig.PortBindings.80.[0].HostPort']) { should eq '8080' }
-  its(['HostConfig.PortBindings.80.[1].HostPort']) { should eq '8081' }  
+  its(['HostConfig.PortBindings.80.[1].HostPort']) { should eq '8081' }
 end
 
 describe docker_container('restarting') do


### PR DESCRIPTION
Hi, nice work on this project!  

Here's some code I'm using at work to write specs like:

```
describe service('some_systemd_service') do
  its('number_of_restarts') { should be 0 }
  its(['RestartUSec']) { should eq '42s' }
```

That's helpful if you have systemd services, and they're setup to auto-restart if they fail, and you'd like to test to ensure that it isn't racking up hundreds of restarts due to something being misconfigured or some fatal problem with the system.  The `[]` accessor I added because it was implemented in the docker_container code and I patterned my work after that.  

I also have a commit in this PR for writing tests such as:

```
it { should have_uptime_greater_than 4 }
```

Which is quite similar to the service test, only tests the docker containers themselves to ensure that they've been online for 'at least a while'.  If people have docker deployments that don't use systemd as the service manager, this will be their best bet for testing whether their containers aren't stuck in a reboot loop.  

Let me know if you have refactor notes and I'll fix things up and open additional PRs as needed.  

And thanks again for getting this framework out there, it's exactly what we needed!