### PR TITLE
Rename the Lxc type to LxcContainer

### DIFF
--- a/lib/serverspec/helper/type.rb
+++ b/lib/serverspec/helper/type.rb
@@ -4,7 +4,7 @@ module Serverspec
       types = %w(
         base bridge bond cgroup command cron default_gateway file fstab
         group host iis_website iis_app_pool interface ipfilter ipnat
-        iptables ip6tables json_file kernel_module kvm linux_kernel_parameter lxc
+        iptables ip6tables json_file kernel_module kvm linux_kernel_parameter lxc_container
         mail_alias mysql_config package php_config port ppa process
         routing_table selinux selinux_module service user yumrepo
         windows_feature windows_hot_fix windows_registry_key

--- a/lib/serverspec/type/lxc_container.rb
+++ b/lib/serverspec/type/lxc_container.rb
@@ -1,5 +1,5 @@
 module Serverspec::Type
-  class Lxc < Base
+  class LxcContainer < Base
     def exists?
       @runner.check_lxc_container_exists(@name)
     end

--- a/spec/type/linux/lxc_container_spec.rb
+++ b/spec/type/linux/lxc_container_spec.rb
@@ -2,11 +2,10 @@ require 'spec_helper'
 
 set :os, :family => 'linux'
 
-describe lxc('ct01') do
+describe lxc_container('ct01') do
   it { should exist }
 end
 
-describe lxc('ct01') do
+describe lxc_container('ct01') do
   it { should be_running }
 end
-


### PR DESCRIPTION
When attempting to run serverspec with the LXC backend the following error occurs:
```
Failure/Error: it { should exist }
     TypeError:
       no implicit conversion of Serverspec::Type::Lxc into String

      /home/omer/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/specinfra-2.73.2/lib/specinfra/backend/lxc.rb:41:in `initialize'
      /home/omer/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/specinfra-2.73.2/lib/specinfra/backend/lxc.rb:41:in `new'
      /home/omer/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/specinfra-2.73.2/lib/specinfra/backend/lxc.rb:41:in `ct'
      /home/omer/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/specinfra-2.73.2/lib/specinfra/backend/lxc.rb:17:in `run_command'
      /home/omer/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/specinfra-2.73.2/lib/specinfra/runner.rb:27:in `run'
      /home/omer/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/specinfra-2.73.2/lib/specinfra/runner.rb:13:in `method_missing'
      /home/omer/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/serverspec-2.41.3/lib/serverspec/type/file.rb:100:in `exists?'
      /home/omer/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/rspec-expectations-3.7.0/lib/rspec/matchers/built_in/exist.rb:76:in `block in existence_values'
      /home/omer/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/rspec-expectations-3.7.0/lib/rspec/matchers/built_in/exist.rb:76:in `map'
      /home/omer/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/rspec-expectations-3.7.0/lib/rspec/matchers/built_in/exist.rb:76:in `existence_values'
      /home/omer/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/rspec-expectations-3.7.0/lib/rspec/matchers/built_in/exist.rb:72:in `uniq_truthy_values'
      /home/omer/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/rspec-expectations-3.7.0/lib/rspec/matchers/built_in/exist.rb:47:in `valid_test?'
      /home/omer/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/rspec-expectations-3.7.0/lib/rspec/matchers/built_in/exist.rb:17:in `matches?'
      /home/omer/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/rspec-expectations-3.7.0/lib/rspec/expectations/handler.rb:50:in `block in handle_matcher'
      /home/omer/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/rspec-expectations-3.7.0/lib/rspec/expectations/handler.rb:27:in `with_matcher'
      /home/omer/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/rspec-expectations-3.7.0/lib/rspec/expectations/handler.rb:48:in `handle_matcher'
      /home/omer/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/rspec-core-3.7.1/lib/rspec/core/memoized_helpers.rb:81:in `should'
      ./spec/packer-sshd-import/ssh_spec.rb:4:in `block (2 levels) in <top (required)>'
      /home/omer/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/rspec-core-3.7.1/lib/rspec/core/example.rb:254:in `instance_exec'
      /home/omer/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/rspec-core-3.7.1/lib/rspec/core/example.rb:254:in `block in run'
      /home/omer/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/rspec-core-3.7.1/lib/rspec/core/example.rb:500:in `block in with_around_and_singleton_context_hooks'
      /home/omer/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/rspec-core-3.7.1/lib/rspec/core/example.rb:457:in `block in with_around_example_hooks'
      /home/omer/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/rspec-core-3.7.1/lib/rspec/core/hooks.rb:466:in `block in run'
      /home/omer/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/rspec-core-3.7.1/lib/rspec/core/hooks.rb:604:in `run_around_example_hooks_for'
      /home/omer/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/rspec-core-3.7.1/lib/rspec/core/hooks.rb:466:in `run'
      /home/omer/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/rspec-core-3.7.1/lib/rspec/core/example.rb:457:in `with_around_example_hooks'
      /home/omer/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/rspec-core-3.7.1/lib/rspec/core/example.rb:500:in `with_around_and_singleton_context_hooks'
      /home/omer/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/rspec-core-3.7.1/lib/rspec/core/example.rb:251:in `run'
      /home/omer/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/rspec-core-3.7.1/lib/rspec/core/example_group.rb:628:in `block in run_examples'
      /home/omer/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/rspec-core-3.7.1/lib/rspec/core/example_group.rb:624:in `map'
      /home/omer/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/rspec-core-3.7.1/lib/rspec/core/example_group.rb:624:in `run_examples'
      /home/omer/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/rspec-core-3.7.1/lib/rspec/core/example_group.rb:590:in `run'
      /home/omer/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/rspec-core-3.7.1/lib/rspec/core/runner.rb:118:in `block (3 levels) in run_specs'
      /home/omer/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/rspec-core-3.7.1/lib/rspec/core/runner.rb:118:in `map'
      /home/omer/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/rspec-core-3.7.1/lib/rspec/core/runner.rb:118:in `block (2 levels) in run_specs'
      /home/omer/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/rspec-core-3.7.1/lib/rspec/core/configuration.rb:1926:in `with_suite_hooks'
      /home/omer/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/rspec-core-3.7.1/lib/rspec/core/runner.rb:113:in `block in run_specs'
      /home/omer/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/rspec-core-3.7.1/lib/rspec/core/reporter.rb:79:in `report'
      /home/omer/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/rspec-core-3.7.1/lib/rspec/core/runner.rb:112:in `run_specs'
      /home/omer/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/rspec-core-3.7.1/lib/rspec/core/runner.rb:87:in `run'
      /home/omer/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/rspec-core-3.7.1/lib/rspec/core/runner.rb:71:in `run'
      /home/omer/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/rspec-core-3.7.1/lib/rspec/core/runner.rb:45:in `invoke'
      /home/omer/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/rspec-core-3.7.1/exe/rspec:4:in `<top (required)>'
      /home/omer/.rbenv/versions/2.5.0/bin/rspec:23:in `load'
      /home/omer/.rbenv/versions/2.5.0/bin/rspec:23:in `<main>'
```
The only way I found to fix this problem is by renaming the Lxc type to LxcContainer. This patch does just that.