### PR TITLE
Fix NoMethodError of belong_*

### DIFF
--- a/lib/serverspec/type/group.rb
+++ b/lib/serverspec/type/group.rb
@@ -7,5 +7,13 @@ module Serverspec::Type
     def has_gid?(gid)
       @runner.check_group_has_gid(@name, gid)
     end
+
+    def belongs_to_group?(group)
+      @runner.check_user_belongs_to_group(@name, group)
+    end
+
+    def belongs_to_primary_group?(group)
+      @runner.check_user_belongs_to_primary_group(@name, group)
+    end
   end
 end


### PR DESCRIPTION
When  belong_to_primary_group or belong_to_group with group like the below, test cases would fail.

- test code

> describe group('apache') do
>       it { should belong_to_primary_group 'apache' }
>       it { should belong_to_group 'apache' } 
> end

- spec execution result

> /usr/local/rbenv/versions/2.5.1/bin/ruby -I/usr/local/rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rspec-support-3.8.0/lib:/usr/local/rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rspec-core-3.8.0/lib /usr/local/rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rspec-core-3.8.0/exe/rspec --pattern spec/localhost/\*_spec.rb
> 
> Group "apache"
>   should belong to primary group "apache" (FAILED - 1)
>   should belong to group "apache" (FAILED - 2)
> 
> Failures:
> 
>   1) Group "apache" should belong to primary group "apache"
>      On host `localhost'
>      Failure/Error: it { should belong_to_primary_group 'apache' }
>      NoMethodError:
>        undefined method `belongs_to_primary_group?' for Group "apache":Serverspec::Type::Group
>        
>       ./spec/localhost/sample_spec.rb:8:in `block (2 levels) in <top (required)>'
> 
>   2) Group "apache" should belong to group "apache"
>      On host `localhost'
>      Failure/Error: it { should belong_to_group 'apache' }
>      NoMethodError:
>        undefined method `belongs_to_group?' for Group "apache":Serverspec::Type::Group
>        
>       ./spec/localhost/sample_spec.rb:9:in `block (2 levels) in <top (required)>'
> 
> Finished in 0.00443 seconds (files took 0.4724 seconds to load)
> 2 examples, 2 failures


After fixing, errors would never occur. Just adding belongs_to_group and belongs_to_primary_group to group.rb, so there is no impact for other functionalities.

- spec execution result after fixing

> /usr/local/rbenv/versions/2.5.1/bin/ruby -I/usr/local/rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rspec-support-3.8.0/lib:/usr/local/rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rspec-core-3.8.0/lib /usr/local/rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rspec-core-3.8.0/exe/rspec --pattern spec/localhost/\*_spec.rb
> 
> Group "apache"
>   should belong to primary group "apache"
>   should belong to group "apache"
> 
> Finished in 0.74851 seconds (files took 0.42018 seconds to load)
> 2 examples, 0 failures`