### PR TITLE
use WinRM::Connection for winrm >= 2.0

### DIFF
--- a/WINDOWS_SUPPORT.md
+++ b/WINDOWS_SUPPORT.md
@@ -26,8 +26,21 @@ user = <username>
 pass = <password>
 endpoint = "http://#{ENV['TARGET_HOST']}:5985/wsman"
 
-winrm = ::WinRM::WinRMWebService.new(endpoint, :ssl, :user => user, :pass => pass, :basic_auth_only => true)
-winrm.set_timeout 300 # 5 minutes max timeout for any operation
+if Gem::Version.new(WinRM::VERSION) < Gem::Version.new('2')
+  winrm = ::WinRM::WinRMWebService.new(endpoint, :ssl, :user => user, :pass => pass, :basic_auth_only => true)
+  winrm.set_timeout 300 # 5 minutes max timeout for any operation
+else
+  opts = {
+    user: user,
+    password: pass,
+    endpoint: endpoint,
+    operation_timeout: 300,
+    no_ssl_peer_verification: false,
+  }
+
+  winrm = ::WinRM::Connection.new(opts)
+end
+
 Specinfra.configuration.winrm = winrm
 ```
 

--- a/lib/serverspec/setup.rb
+++ b/lib/serverspec/setup.rb
@@ -308,8 +308,21 @@ user = <username>
 pass = <password>
 endpoint = "http://#{ENV['TARGET_HOST']}:5985/wsman"
 
-winrm = ::WinRM::WinRMWebService.new(endpoint, :ssl, :user => user, :pass => pass, :basic_auth_only => true)
-winrm.set_timeout 300 # 5 minutes max timeout for any operation
+if Gem::Version.new(WinRM::VERSION) < Gem::Version.new('2')
+  winrm = ::WinRM::WinRMWebService.new(endpoint, :ssl, :user => user, :pass => pass, :basic_auth_only => true)
+  winrm.set_timeout 300 # 5 minutes max timeout for any operation
+else
+  opts = {
+    user: user,
+    password: pass,
+    endpoint: endpoint,
+    operation_timeout: 300,
+    no_ssl_peer_verification: false,
+  }
+
+  winrm = ::WinRM::Connection.new(opts)
+end
+
 Specinfra.configuration.winrm = winrm
 <% end -%>
 EOF


### PR DESCRIPTION
spec_helper raises `uninitialized constant WinRM::WinRMWebService` since winrm 2.0. So, I branched the initialization of winrm instance.

- use WinRM::Connection for winrm 2.x
- [compatibility] winrm >= 2.0 doesn't support ruby 1.9

Since the backend of specinfra also needs updating, I will make a PR to specinfra as well.