### PR TITLE
Fix service is_enabled test when using under()

### DIFF
--- a/lib/serverspec/type/service.rb
+++ b/lib/serverspec/type/service.rb
@@ -1,7 +1,8 @@
 module Serverspec::Type
   class Service < Base
     def enabled?(level, under=nil)
-      check_method = "check_service_is_enabled" + (under ? "_#{under}" : '')
+      under = under ? "_under_#{under.gsub(/^under_/, '')}" : ''
+      check_method = "check_service_is_enabled#{under}"
 
       if level
         @runner.send(check_method.to_sym, @name, level)


### PR DESCRIPTION
Currently running something like:
```
expect(service('foo')).to be_enabled.under('runit')
```

throws something like:
```
NotImplementedError:
    check_is_enabled_runit is not implemented in Specinfra::Command::Ubuntu::V15::Service
```

This is because the actual method is called `check_is_enabled_under_runit`. 

This PR fixes the method name in a way that previous hacks using `expect(service('foo')).to be_enabled.under('under_runit')` will still work.