### PR TITLE
Add a curl_command type

### DIFF
--- a/lib/serverspec/helper/type.rb
+++ b/lib/serverspec/helper/type.rb
@@ -2,8 +2,8 @@ module Serverspec
   module Helper
     module Type
       types = %w(
-        base bridge bond cgroup command cron default_gateway file fstab
-        group host iis_website iis_app_pool interface ipfilter ipnat
+        base bridge bond cgroup command cron curl_command default_gateway file
+        fstab group host iis_website iis_app_pool interface ipfilter ipnat
         iptables ip6tables json_file kernel_module kvm linux_kernel_parameter lxc
         mail_alias mysql_config package php_config port ppa process
         routing_table selinux selinux_module service user yumrepo

--- a/lib/serverspec/type/curl_command.rb
+++ b/lib/serverspec/type/curl_command.rb
@@ -1,0 +1,48 @@
+module Serverspec
+  module Type
+    class CurlCommand < Command
+      def response_code
+        m = /Response-Code: (?<code>\d+)/.match(stderr)
+        return 0 unless m
+        m[:code].to_i
+      end
+
+      def body
+        command_result.stdout
+      end
+
+      def body_as_json
+        MultiJson.load(body)
+      end
+
+      private
+
+      def curl_command
+        command = "curl --silent --write-out '%{stderr}Response-Code: %{response_code}\\n' '#{@name}'"
+
+        @options.each do |option, value|
+          case option
+          when :cacert, :cert, :key
+            command += " --#{option} '#{value}'"
+          when :headers
+            value.each do |header, header_value|
+              if header_value
+                command += " --header '#{header}: #{header_value}'"
+              else
+                command += " --header '#{header};'"
+              end
+            end
+          else
+            raise "Unknown option #{option} (value: #{value})"
+          end
+        end
+
+        command
+      end
+
+      def command_result
+        @command_result ||= @runner.run_command(curl_command)
+      end
+    end
+  end
+end

--- a/spec/type/base/curl_command_spec.rb
+++ b/spec/type/base/curl_command_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+set :os, :family => 'base'
+
+describe '#response_code' do
+  describe curl_command('http://example.com') do
+    let(:stderr) { 'Response-Code: 200' }
+    its(:response_code) { should eq(200) }
+  end
+end
+
+describe '#body' do
+  describe curl_command('http://example.com/index.html') do
+    let(:stdout) { '<title>Example Domain</title>' }
+    its(:body) { should contain 'Example Domain' }
+  end
+end
+
+describe '#body_as_json' do
+  describe curl_command('http://example.com/content.json') do
+    let(:stdout) { '{"key":1234}' }
+    its(:body_as_json) { should eq({"key" => 1234}) }
+  end
+end
+
+describe '#curl_command' do
+  describe curl_command('http://example.com/content.json') do
+    it { expect(subject.send(:curl_command)).to eq("curl --silent --write-out '%{stderr}Response-Code: %{response_code}\\n' 'http://example.com/content.json'") }
+  end
+
+  describe curl_command('http://example.com/content.json', cacert: '/ca.pem', cert: '/cert.pem', key: '/key.pem', headers: {'Accept' => 'application/json', 'Built-In' => nil}) do
+    it { expect(subject.send(:curl_command)).to eq("curl --silent --write-out '%{stderr}Response-Code: %{response_code}\\n' 'http://example.com/content.json' --cacert '/ca.pem' --cert '/cert.pem' --key '/key.pem' --header 'Accept: application/json' --header 'Built-In;'") }
+  end
+end


### PR DESCRIPTION
With this type, it should be easy to perform HTTP requests inside systems.

It writes out the response code to stderr so it's easy to parse. Curl 7.70.0 supports --write-out %{json} but that's effectively unavailable because it's so new.

I'm interested if other things should be exposed, such as the Content-Type header. Also passing headers on the command line might be a common scenario. I'm submitting this PR early to get feedback on whether this type is desired at all and if so, if I'm on the right track.