### PR TITLE
Normalize openssl issuer and subject

### DIFF
--- a/lib/serverspec/type/x509_certificate.rb
+++ b/lib/serverspec/type/x509_certificate.rb
@@ -7,11 +7,11 @@ module Serverspec::Type
     end
 
     def subject
-      run_openssl_command_with("-subject -noout").stdout.chomp.gsub(/^subject= */,'')
+      normalize_dn(run_openssl_command_with("-subject -noout").stdout.chomp.gsub(/^subject= */,''))
     end
 
     def issuer
-      run_openssl_command_with("-issuer -noout").stdout.chomp.gsub(/^issuer= */,'')
+      normalize_dn(run_openssl_command_with("-issuer -noout").stdout.chomp.gsub(/^issuer= */,''))
     end
 
     def email
@@ -80,6 +80,13 @@ module Serverspec::Type
         time = Time.strptime(kv_arr[1],'%b %e %T %Y %Z') rescue Time.parse(kv_arr[1] || '')
         res.merge({ kv_arr[0].to_sym => time })
       end
+    end
+
+    # Normalize output between openssl versions.
+    def normalize_dn(dn)
+      return subject unless subject.start_with?('/')
+      # normalize openssl >= 1.1 to < 1.1 output
+      subject[1..-1].split('/').join(', ').gsub('=', ' = ')
     end
   end
 end


### PR DESCRIPTION
In OpenSSL < 1.1 (as found on EL7 and older distros) the output was:

    issuer=/C=US/O=Let's Encrypt/CN=R3

In OpenSSL >= 1.1 (as found on EL8 and newer distros) the output is:

    issuer=C = US, O = Let's Encrypt, CN = R3

This normalizes the output to the old pre-1.1 style. This makes it easier to write a test that should pass on both platforms.

The downside of this is that we're normalizing to an older output format, but that makes backwards compatiblity easier. An alternative is to introduce new helpers that are normalized. It may also be a chance to thing you the DN should be presented as an array instead of a single string.