### PR TITLE
Fixed infinite loop in subject of x509_certificate

### DIFF
--- a/lib/serverspec/type/x509_certificate.rb
+++ b/lib/serverspec/type/x509_certificate.rb
@@ -85,7 +85,7 @@ module Serverspec::Type
     # Normalize output between openssl versions.
     def normalize_dn(dn)
       return dn unless dn.start_with?('/')
-      # normalize openssl >= 1.1 to < 1.1 output
+      # normalize openssl < 1.1 to >= 1.1 output
       dn[1..-1].split('/').join(', ').gsub('=', ' = ')
     end
   end

--- a/lib/serverspec/type/x509_certificate.rb
+++ b/lib/serverspec/type/x509_certificate.rb
@@ -84,9 +84,9 @@ module Serverspec::Type
 
     # Normalize output between openssl versions.
     def normalize_dn(dn)
-      return subject unless subject.start_with?('/')
+      return dn unless dn.start_with?('/')
       # normalize openssl >= 1.1 to < 1.1 output
-      subject[1..-1].split('/').join(', ').gsub('=', ' = ')
+      dn[1..-1].split('/').join(', ').gsub('=', ' = ')
     end
   end
 end

--- a/spec/type/linux/x509_certificate_spec.rb
+++ b/spec/type/linux/x509_certificate_spec.rb
@@ -17,8 +17,18 @@ describe x509_certificate('test-openssl-1.0.pem') do
   its(:subject) { should eq 'O = some, OU = thing' }
 end
 
+describe x509_certificate('test-openssl-1.1.pem') do
+  let(:stdout) { sample_subj_openssl_1_1 }
+  its(:subject) { should eq 'O = some, OU = thing' }
+end
+
 describe x509_certificate('test-openssl-1.0.pem') do
   let(:stdout) { sample_issuer_openssl_1_0 }
+  its(:issuer) { should eq 'O = some, OU = issuer' }
+end
+
+describe x509_certificate('test-openssl-1.1.pem') do
+  let(:stdout) { sample_issuer_openssl_1_1 }
   its(:issuer) { should eq 'O = some, OU = issuer' }
 end
 
@@ -44,9 +54,21 @@ subject= /O=some/OU=thing
 EOS
 end
 
+def sample_subj_openssl_1_1
+  <<'EOS'
+subject=O = some, OU = thing
+EOS
+end
+
 def sample_issuer_openssl_1_0
   <<'EOS'
 issuer= /O=some/OU=issuer
+EOS
+end
+
+def sample_issuer_openssl_1_1
+  <<'EOS'
+issuer=O = some, OU = issuer
 EOS
 end
 

--- a/spec/type/linux/x509_certificate_spec.rb
+++ b/spec/type/linux/x509_certificate_spec.rb
@@ -12,14 +12,14 @@ describe x509_certificate('test.pem') do
   it { should_not be_certificate }
 end
 
-describe x509_certificate('test.pem') do
-  let(:stdout) { sample_subj }
-  its(:subject) { should eq '/O=some/OU=thing' }
+describe x509_certificate('test-openssl-1.0.pem') do
+  let(:stdout) { sample_subj_openssl_1_0 }
+  its(:subject) { should eq 'O = some, OU = thing' }
 end
 
-describe x509_certificate('test.pem') do
-  let(:stdout) { sample_issuer }
-  its(:issuer) { should eq '/O=some/OU=issuer' }
+describe x509_certificate('test-openssl-1.0.pem') do
+  let(:stdout) { sample_issuer_openssl_1_0 }
+  its(:issuer) { should eq 'O = some, OU = issuer' }
 end
 
 describe x509_certificate('test.pem') do
@@ -38,13 +38,13 @@ describe x509_certificate('test.pem') do
   its(:subject_alt_names) { should eq %w[DNS:*.example.com DNS:www.example.net IP:192.0.2.10] }
 end
 
-def sample_subj
+def sample_subj_openssl_1_0
   <<'EOS'
 subject= /O=some/OU=thing
 EOS
 end
 
-def sample_issuer
+def sample_issuer_openssl_1_0
   <<'EOS'
 issuer= /O=some/OU=issuer
 EOS


### PR DESCRIPTION
With serverspec 2.41.6, I got infinite loop in subject of x509_certificate.

test code:

```ruby
require 'spec_helper'

describe x509_certificate("/tmp/example.crt") do
  its(:subject) { should eq 'O = some, OU = thing, CN = www.example.com' }
end
```

output:

```
% bundle exec rake spec
/opt/rbenv/versions/3.0.1/bin/ruby -I/tmp/a/vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib:/tmp/a/vendor/bundle/ruby/3.0.0/gems/rspec-support-3.10.2/lib /tmp/a/vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/exe/rspec --pattern spec/localhost/\*_spec.rb

X509 certificate "/tmp/example.crt"
  subject
    example at ./spec/localhost/sample_spec.rb:4 (FAILED - 1)

Failures:

  1) X509 certificate "/tmp/example.crt" subject 
     On host `localhost'
     Failure/Error: its(:subject) { should eq 'O = some, OU = thing, CN = www.example.com' }
     SystemStackError:
       stack level too deep
       /bin/sh -c openssl\ x509\ -in\ /tmp/example.crt\ -subject\ -noout
       subject=O = some, OU = thing, CN = www.example.com

     # ./vendor/bundle/ruby/3.0.0/gems/specinfra-2.82.25/lib/specinfra/configuration.rb:60:in `method_missing'
     # ./vendor/bundle/ruby/3.0.0/gems/specinfra-2.82.25/lib/specinfra/backend/base.rb:21:in `get_config'
     # ./vendor/bundle/ruby/3.0.0/gems/specinfra-2.82.25/lib/specinfra/backend/exec.rb:33:in `build_command'
     # ./vendor/bundle/ruby/3.0.0/gems/specinfra-2.82.25/lib/specinfra/backend/exec.rb:10:in `run_command'
     # ./vendor/bundle/ruby/3.0.0/gems/specinfra-2.82.25/lib/specinfra/runner.rb:11:in `method_missing'
     # ./vendor/bundle/ruby/3.0.0/gems/serverspec-2.41.6/lib/serverspec/type/x509_certificate.rb:74:in `run_openssl_command_with'
     # ./vendor/bundle/ruby/3.0.0/gems/serverspec-2.41.6/lib/serverspec/type/x509_certificate.rb:10:in `subject'
     # ./vendor/bundle/ruby/3.0.0/gems/serverspec-2.41.6/lib/serverspec/type/x509_certificate.rb:87:in `normalize_dn'
     # ./vendor/bundle/ruby/3.0.0/gems/serverspec-2.41.6/lib/serverspec/type/x509_certificate.rb:10:in `subject'
     # ./vendor/bundle/ruby/3.0.0/gems/serverspec-2.41.6/lib/serverspec/type/x509_certificate.rb:87:in `normalize_dn'
     # ./vendor/bundle/ruby/3.0.0/gems/serverspec-2.41.6/lib/serverspec/type/x509_certificate.rb:10:in `subject'
     # ./vendor/bundle/ruby/3.0.0/gems/serverspec-2.41.6/lib/serverspec/type/x509_certificate.rb:87:in `normalize_dn'
     # (...snip...)
     # (...snip...)
     # (...snip...)
     # ./vendor/bundle/ruby/3.0.0/gems/serverspec-2.41.6/lib/serverspec/type/x509_certificate.rb:87:in `normalize_dn'
     # ./vendor/bundle/ruby/3.0.0/gems/serverspec-2.41.6/lib/serverspec/type/x509_certificate.rb:10:in `subject'
     # ./vendor/bundle/ruby/3.0.0/gems/serverspec-2.41.6/lib/serverspec/type/x509_certificate.rb:87:in `normalize_dn'
     # ./vendor/bundle/ruby/3.0.0/gems/serverspec-2.41.6/lib/serverspec/type/x509_certificate.rb:10:in `subject'
     # ./vendor/bundle/ruby/3.0.0/gems/serverspec-2.41.6/lib/serverspec/type/x509_certificate.rb:87:in `normalize_dn'
     # ./vendor/bundle/ruby/3.0.0/gems/serverspec-2.41.6/lib/serverspec/type/x509_certificate.rb:10:in `subject'
     # ./spec/localhost/sample_spec.rb:4:in `block (2 levels) in <top (required)>'

Finished in 26.49 seconds (files took 0.28308 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/localhost/sample_spec.rb:4 # X509 certificate "/tmp/example.crt" subject 

/opt/rbenv/versions/3.0.1/bin/ruby -I/tmp/a/vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib:/tmp/a/vendor/bundle/ruby/3.0.0/gems/rspec-support-3.10.2/lib /tmp/a/vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/exe/rspec --pattern spec/localhost/\*_spec.rb failed
```

(The certificate file /tmp/example.crt is created by `openssl req -x509 -newkey rsa:4096 -keyout /tmp/example.key -out /tmp/example.crt -days 365 -subj "/O=some/OU=thing/CN=www.example.com" -nodes`)

I found a bug in #614, and fixed by 8f07db8, and added tests (041a052, 527437a).

In #614, I found the following description

> This normalizes the output to the old pre-1.1 style.

but it seems to be incorrect.
The implementation is to normalize to the 1.1 style (not pre-1.1 style), right?

