### PR TITLE
Provide user uid and group gid as properties

### DIFF
--- a/lib/serverspec/type/group.rb
+++ b/lib/serverspec/type/group.rb
@@ -4,6 +4,10 @@ module Serverspec::Type
       @runner.check_group_exists(@name)
     end
 
+    def gid
+      @runner.get_group_gid(@name).stdout.to_i
+    end
+
     def has_gid?(gid)
       @runner.check_group_has_gid(@name, gid)
     end

--- a/lib/serverspec/type/user.rb
+++ b/lib/serverspec/type/user.rb
@@ -12,6 +12,10 @@ module Serverspec::Type
       @runner.check_user_belongs_to_primary_group(@name, group)
     end
 
+    def uid
+      @runner.get_user_uid(@name).stdout.to_i
+    end
+
     def has_uid?(uid)
       @runner.check_user_has_uid(@name, uid)
     end

--- a/spec/type/base/group_spec.rb
+++ b/spec/type/base/group_spec.rb
@@ -9,3 +9,8 @@ end
 describe group('root') do
   it { should have_gid 0 }
 end
+
+describe group('root') do
+  its(:gid) { should == 0 }
+  its(:gid) { should < 10 }
+end

--- a/spec/type/base/user_spec.rb
+++ b/spec/type/base/user_spec.rb
@@ -19,6 +19,11 @@ describe user('root') do
 end
 
 describe user('root') do
+  its(:uid) { should == 0 }
+  its(:uid) { should < 10 }
+end
+
+describe user('root') do
   it { should have_login_shell '/bin/bash' }
 end
 


### PR DESCRIPTION
This allows using a common matcher, which can be used to determine a group is somewhere in a range. For example, checking that a user is a system user with uid < 1000.