### PR TITLE
Relax rake dependency pinning

### DIFF
--- a/serverspec.gemspec
+++ b/serverspec.gemspec
@@ -22,6 +22,11 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "rspec-its"
   spec.add_runtime_dependency "multi_json"
   spec.add_runtime_dependency "specinfra", "~> 2.72"
-  spec.add_development_dependency("json", "~> 1.8") if RUBY_VERSION < "1.9"
-  spec.add_development_dependency "rake", "~> 10.1.1"
+
+  if RUBY_VERSION < "1.9"
+    spec.add_development_dependency "json", "~> 1.8"
+    spec.add_development_dependency "rake", "~> 10.1.1"
+  else
+    spec.add_development_dependency "rake"
+  end
 end


### PR DESCRIPTION
This gem seems to use rake 10.1 to support Ruby 1.8.   
see: 64b30721

However, rake 10.1 does not work with Ruby 3.2 because Object#=~ has been removed.   
(which raises a NoMethodError exception)

So I have removed the version limitation of rake in Ruby 1.9 and later development environments.