### PR TITLE
Support Psych 4.0 (Ruby 3.1) or later

### DIFF
--- a/lib/serverspec/type/file.rb
+++ b/lib/serverspec/type/file.rb
@@ -121,7 +121,13 @@ module Serverspec::Type
     end
 
     def content_as_yaml
-      @content_as_yaml = YAML.load(content) if @content_as_yaml.nil?
+      if @content_as_yaml.nil?
+        @content_as_yaml = if YAML.respond_to?(:unsafe_load)
+                             YAML.unsafe_load(content)
+                           else
+                             YAML.load(content)
+                           end
+      end
       @content_as_yaml
     end
 

--- a/spec/type/base/file_spec.rb
+++ b/spec/type/base/file_spec.rb
@@ -369,18 +369,22 @@ describe file('example.yml') do
   let(:stdout) {<<EOF
 ---
 yaml:
-  title: 'this is a yaml'
+  title: &anchor 'this is a yaml'
   array:
     -
       title: 'array 1'
     -
       title: 'array 2'
+  date: 2023-02-03
+  Reuse anchor: *anchor
 EOF
   }
 
   its(:content_as_yaml) { should include('yaml') }
   its(:content_as_yaml) { should include('yaml' => include('title' => 'this is a yaml')) }
   its(:content_as_yaml) { should include('yaml' => include('array' => include('title' => 'array 2'))) }
+  its(:content_as_yaml) { should include('yaml' => include('date' => Date.new(2023, 2, 3))) }
+  its(:content_as_yaml) { should include('yaml' => include('Reuse anchor' => 'this is a yaml')) }
 end
 
 


### PR DESCRIPTION
In Psych 4.0, which shipped with Ruby 3.1, Psych.load has been changed to use safe_load by default, so some documents cannot be loaded with the file resource type :content_as_yaml.

Psych 3.3.2 introduced the unsafe_load method to load trusted documents, so I changed it to use it.