### PR TITLE
Use the newer ERB.new usage for Ruby v2.6 or higher

### DIFF
--- a/lib/serverspec/setup.rb
+++ b/lib/serverspec/setup.rb
@@ -152,7 +152,12 @@ EOF
     end
 
     def self.safe_create_spec_helper
-      content = ERB.new(spec_helper_template, nil, '-').result(binding)
+      erb = if RUBY_VERSION >= "2.6"
+              ERB.new(spec_helper_template, :trim_mode => '-')
+            else
+              ERB.new(spec_helper_template, nil, '-')
+            end
+      content = erb.result(binding)
       if File.exist? 'spec/spec_helper.rb'
         old_content = File.read('spec/spec_helper.rb')
         if old_content != content


### PR DESCRIPTION
Hello,

This patch suppresses the `ERB.new` warning when calling `serverspec-init` with newer versions of Ruby:

```
$ serverspec-init
...
Vagrant instance y/n: n
Input target host name: pi
 + spec/
 + spec/pi/
 + spec/pi/sample_spec.rb
.../lib/serverspec/setup.rb:155: warning: Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments.
.../lib/serverspec/setup.rb:155: warning: Passing trim_mode with the 3rd argument of ERB.new is deprecated. Use keyword argument like ERB.new(str, trim_mode: ...) instead.
 + spec/spec_helper.rb
 + Rakefile
 + .rspec
```

Reference:

* Ruby 2.6.0 Released - Other notable changes since 2.5 [^1]

  > Passing safe_level to ERB.new is deprecated. ...

* Ruby Issue Tracking System - Deprecate `$SAFE` support in ERB and let `ERB.new` take keyword arguments for it [^2]

Thanks,

[^1]: https://www.ruby-lang.org/en/news/2018/12/25/ruby-2-6-0-released/
[^2]: https://bugs.ruby-lang.org/issues/14256
